### PR TITLE
Added `rest` in view supported catalogs and added view type if we encounter view metadata

### DIFF
--- a/iomete-catalog-sync/catalog-sync-job/Makefile
+++ b/iomete-catalog-sync/catalog-sync-job/Makefile
@@ -1,5 +1,5 @@
 image := iomete.azurecr.io/iomete/iom-catalog-sync
-tag   := 4.3.1
+tag   := 4.3.2
 
 spark_submit_cmd := /opt/spark/bin/spark-submit \
 			--properties-file=/opt/spark/conf/spark-defaults.conf \

--- a/iomete-catalog-sync/catalog-sync-job/src/main/kotlin/com/iomete/catalogsync/LakehouseMetadataExtractor.kt
+++ b/iomete-catalog-sync/catalog-sync-job/src/main/kotlin/com/iomete/catalogsync/LakehouseMetadataExtractor.kt
@@ -49,7 +49,7 @@ class LakehouseMetadataExtractor(
     private val excludeSchemas: Set<String> = applicationConfig.excludeSchemas().orElse(setOf())
     
     private val catalogViewSupport = ConcurrentHashMap<String, Boolean>()
-    private val viewSupportedCatalogTypes = setOf("iceberg", "glue")
+    private val viewSupportedCatalogTypes = setOf("iceberg", "glue", "rest")
 
     fun scrape(appConfig: AppConfig) {
         val catalogs = getCatalog(appConfig)
@@ -419,7 +419,7 @@ class LakehouseMetadataExtractor(
             "# Partitioning" to TableColumnSection.PARTITIONS,
             "# Metadata Columns" to TableColumnSection.METADATA,
             "# Detailed Table Information" to TableColumnSection.TABLE_INFO,
-            "# Detailed View Information" to TableColumnSection.TABLE_INFO
+            "# Detailed View Information" to TableColumnSection.VIEW_INFO
         )
 
         val columnsMap = mutableMapOf<String, ColumnMetadata>()
@@ -436,6 +436,10 @@ class LakehouseMetadataExtractor(
 
                 if (matchedSection != null) {
                     currentSection = matchedSection
+                    
+                    if (currentSection == TableColumnSection.VIEW_INFO) {
+                        metadataMap["Type"] = "view"
+                    }
                 }
 
                 continue
@@ -462,7 +466,7 @@ class LakehouseMetadataExtractor(
                             columnName
                     columnsMap[partitionColName]?.isPartitionKey = true
                 }
-                TableColumnSection.TABLE_INFO -> {
+                TableColumnSection.TABLE_INFO, TableColumnSection.VIEW_INFO -> {
                     metadataMap[columnName] = dataType
                 }
                 TableColumnSection.METADATA -> {

--- a/iomete-catalog-sync/catalog-sync-job/src/main/kotlin/com/iomete/catalogsync/Model.kt
+++ b/iomete-catalog-sync/catalog-sync-job/src/main/kotlin/com/iomete/catalogsync/Model.kt
@@ -65,5 +65,6 @@ enum class TableColumnSection {
     COLUMNS,
     PARTITIONS,
     METADATA,
-    TABLE_INFO
+    TABLE_INFO,
+    VIEW_INFO
 }


### PR DESCRIPTION
Added `rest` in view supported catalogs and added view type if we encounter view metadata

Ticket: https://linear.app/iomete/issue/SUP-529/cannot-see-the-views