### PR TITLE
Cleanup summary log readability clean

### DIFF
--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/config/Config.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/config/Config.kt
@@ -31,7 +31,29 @@ data class ApplicationConfig(
 
     @field:JsonProperty("max_candidate_folders_per_database")
     val maxCandidateFoldersPerDatabase: Int = 10,
-)
+) {
+    fun validate() {
+        require(catalog.isNotBlank()) { "catalog must not be blank" }
+
+        require(databases.isNotEmpty()) {
+            "databases must contain at least one database name"
+        }
+
+        require(olderThanHours >= 0) {
+            "older_than_hours must be greater than or equal to 0"
+        }
+
+        require(maxCandidateFoldersPerDatabase >= 0) {
+            "max_candidate_folders_per_database must be greater than or equal to 0"
+        }
+
+        if (!dryRun) {
+            require(deleteEnabled) {
+                "delete_enabled must be true when dry_run is false"
+            }
+        }
+    }
+}
 
 @ApplicationScoped
 class ConfigProducer {
@@ -53,6 +75,6 @@ class ConfigProducer {
             .registerModule(KotlinModule.Builder().build())
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
 
-        return objectMapper.readValue(configFile)
+        return objectMapper.readValue<ApplicationConfig>(configFile).also { it.validate() }
     }
 }

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -382,26 +382,33 @@ class CleanupUntrackedTableFoldersService {
 
         val nonCandidateStorageFolderPaths =
             storageFolderPaths.filter { it !in candidateFolderSet }.sorted()
+        logger.info("")
+
+        logger.info("")
+
+        logger.info("")
 
         logger.info("========== Cleanup Untracked Table Folders Summary ==========")
 
         logger.info("Catalog: $catalog")
 
-        logger.info("Database: $database")
+        logger.info("Configured database: $database")
 
         logger.info("Discovered database location: $discoveredDatabaseLocation")
 
-        logger.info("Storage scan location: $storageScanLocation")
+        logger.info("Object storage scan root: $storageScanLocation")
 
-        logger.info("Active table location count: ${activeTableLocations.size}")
+        logger.info("Catalog active table location count: ${activeTableLocations.size}")
 
-        logger.info("Storage folder count: ${storageFolderPaths.size}")
+        logger.info("Immediate child storage folders scanned: ${storageFolderPaths.size}")
 
-        logger.info("Candidate folder count: ${candidateFolderPaths.size}")
+        logger.info("Untracked candidate folder count: ${candidateFolderPaths.size}")
+
+        logger.info("Deleted folder count: ${deletedFolderPaths.size}")
 
         logger.info("Deletion performed: ${deletedFolderPaths.isNotEmpty()}")
 
-        logger.info("Protected active table folders:")
+        logger.info("Protected catalog active table locations:")
 
         logListOrNone(protectedFolderPaths.sorted())
 
@@ -409,7 +416,7 @@ class CleanupUntrackedTableFoldersService {
 
         logListOrNone(nonCandidateStorageFolderPaths)
 
-        logger.info("Candidate folders selected for cleanup:")
+        logger.info("Untracked candidate folders selected for cleanup:")
 
         logListOrNone(candidateFolderPaths)
 
@@ -418,6 +425,13 @@ class CleanupUntrackedTableFoldersService {
         logListOrNone(deletedFolderPaths)
 
         logger.info("============================================================")
+
+        logger.info("")
+
+        logger.info("")
+
+        logger.info("")
+
     }
 
     private fun logListOrNone(values: List<String>) {


### PR DESCRIPTION
## Summary

Applies two small cleanup job follow-up improvements.

Changes:
- Improves cleanup summary log readability and labels
- Moves config-level validation into `ApplicationConfig` / config loading
- Fails fast if required config is missing or invalid
- Fails fast on unknown config fields instead of silently ignoring typos

No cleanup, deletion, audit schema, or candidate detection behavior changed.

## Testing

- `./gradlew clean test`
- `./gradlew clean quarkusBuild`