### PR TITLE
Improve cleanup audit schema readability

### DIFF
--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditRecord.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditRecord.kt
@@ -3,15 +3,21 @@ package com.iomete.cleanup.untrackedtablefolders.audit
 import java.time.Instant
 
 data class CleanupAuditRecord(
-    val sparkAppId: String?,
     val runId: String,
+    val sparkAppId: String?,
     val initiatedBy: String?,
     val catalogName: String,
     val databaseName: String,
     val operation: String,
     val dryRun: Boolean,
     val deleteEnabled: Boolean,
+    val olderThanHours: Long,
+    val cutoffTime: Instant?,
+    val maxCandidateFoldersPerDatabase: Int,
+    val excludedPaths: List<String>,
     val status: String,
+    val statusReason: String?,
+    val errorMessage: String?,
     val discoveredDatabaseLocation: String?,
     val storageScanLocation: String,
     val activeTableCount: Long,
@@ -20,9 +26,7 @@ data class CleanupAuditRecord(
     val deletedFolderCount: Long,
     val candidateFolders: List<String>,
     val deletedFolders: List<String>,
-    val excludedPaths: List<String>,
-    val metrics: Map<String, String>,
-    val errorMessage: String?,
+    val diagnosticDetails: Map<String, String>,
     val startTime: Instant,
     val endTime: Instant,
 )

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditTableService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditTableService.kt
@@ -60,7 +60,34 @@ class CleanupAuditTableService {
 
         sparkSessionProvider.getOrCreate().sql(
             """
-            INSERT INTO $AUDIT_TABLE_NAME
+            INSERT INTO $AUDIT_TABLE_NAME (
+              run_id,
+              spark_app_id,
+              initiated_by,
+              catalog_name,
+              database_name,
+              operation,
+              dry_run,
+              delete_enabled,
+              older_than_hours,
+              cutoff_time,
+              max_candidate_folders_per_database,
+              excluded_paths,
+              status,
+              status_reason,
+              error_message,
+              discovered_database_location,
+              storage_scan_location,
+              active_table_count,
+              storage_folder_count,
+              candidate_folder_count,
+              deleted_folder_count,
+              candidate_folders,
+              deleted_folders,
+              diagnostic_details,
+              start_time,
+              end_time
+            )
             SELECT
               ${sqlString(record.runId)} AS run_id,
               ${sqlNullableString(record.sparkAppId)} AS spark_app_id,

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditTableService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditTableService.kt
@@ -20,15 +20,21 @@ class CleanupAuditTableService {
         sparkSessionProvider.getOrCreate().sql(
             """
             CREATE TABLE IF NOT EXISTS $AUDIT_TABLE_NAME (
-              spark_app_id STRING,
               run_id STRING,
+              spark_app_id STRING,
               initiated_by STRING,
               catalog_name STRING,
               database_name STRING,
               operation STRING,
               dry_run BOOLEAN,
               delete_enabled BOOLEAN,
+              older_than_hours BIGINT,
+              cutoff_time TIMESTAMP,
+              max_candidate_folders_per_database INT,
+              excluded_paths ARRAY<STRING>,
               status STRING,
+              status_reason STRING,
+              error_message STRING,
               discovered_database_location STRING,
               storage_scan_location STRING,
               active_table_count BIGINT,
@@ -37,9 +43,7 @@ class CleanupAuditTableService {
               deleted_folder_count BIGINT,
               candidate_folders ARRAY<STRING>,
               deleted_folders ARRAY<STRING>,
-              excluded_paths ARRAY<STRING>,
-              metrics MAP<STRING, STRING>,
-              error_message STRING,
+              diagnostic_details MAP<STRING, STRING>,
               start_time TIMESTAMP,
               end_time TIMESTAMP
             )
@@ -58,15 +62,21 @@ class CleanupAuditTableService {
             """
             INSERT INTO $AUDIT_TABLE_NAME
             SELECT
-              ${sqlNullableString(record.sparkAppId)} AS spark_app_id,
               ${sqlString(record.runId)} AS run_id,
+              ${sqlNullableString(record.sparkAppId)} AS spark_app_id,
               ${sqlNullableString(record.initiatedBy)} AS initiated_by,
               ${sqlString(record.catalogName)} AS catalog_name,
               ${sqlString(record.databaseName)} AS database_name,
               ${sqlString(record.operation)} AS operation,
               ${record.dryRun} AS dry_run,
               ${record.deleteEnabled} AS delete_enabled,
+              ${record.olderThanHours}L AS older_than_hours,
+              ${sqlNullableTimestamp(record.cutoffTime)} AS cutoff_time,
+              ${record.maxCandidateFoldersPerDatabase} AS max_candidate_folders_per_database,
+              ${sqlStringArray(record.excludedPaths)} AS excluded_paths,
               ${sqlString(record.status)} AS status,
+              ${sqlNullableString(record.statusReason)} AS status_reason,
+              ${sqlNullableString(record.errorMessage)} AS error_message,
               ${sqlNullableString(record.discoveredDatabaseLocation)} AS discovered_database_location,
               ${sqlString(record.storageScanLocation)} AS storage_scan_location,
               ${record.activeTableCount}L AS active_table_count,
@@ -75,9 +85,7 @@ class CleanupAuditTableService {
               ${record.deletedFolderCount}L AS deleted_folder_count,
               ${sqlStringArray(record.candidateFolders)} AS candidate_folders,
               ${sqlStringArray(record.deletedFolders)} AS deleted_folders,
-              ${sqlStringArray(record.excludedPaths)} AS excluded_paths,
-              ${sqlStringMap(record.metrics)} AS metrics,
-              ${sqlNullableString(record.errorMessage)} AS error_message,
+              ${sqlStringMap(record.diagnosticDetails)} AS diagnostic_details,
               ${sqlTimestamp(record.startTime)} AS start_time,
               ${sqlTimestamp(record.endTime)} AS end_time
             """.trimIndent()
@@ -121,6 +129,9 @@ class CleanupAuditTableService {
 
     private fun sqlTimestamp(value: Instant): String =
         "TIMESTAMP '${Timestamp.from(value)}'"
+
+    private fun sqlNullableTimestamp(value: Instant?): String =
+        value?.let { sqlTimestamp(it) } ?: "CAST(NULL AS TIMESTAMP)"
 
     companion object {
         const val AUDIT_TABLE_NAME =

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -20,17 +20,11 @@ import org.jboss.logging.Logger
 class CleanupUntrackedTableFoldersService {
 
     private val logger = Logger.getLogger(CleanupUntrackedTableFoldersService::class.java)
-
     @Inject lateinit var config: ApplicationConfig
-
     @Inject lateinit var catalogDiscoveryService: CatalogDiscoveryService
-
     @Inject lateinit var objectStorageDiscoveryService: ObjectStorageDiscoveryService
-
     @Inject lateinit var objectStorageDeletionService: ObjectStorageDeletionService
-
     @Inject lateinit var untrackedFolderCandidateDetector: UntrackedFolderCandidateDetector
-
     @Inject lateinit var cleanupAuditTableService: CleanupAuditTableService
 
     fun run() {
@@ -66,50 +60,17 @@ class CleanupUntrackedTableFoldersService {
                         "Skipping storage folder discovery because database location is missing for catalog=${discoveredDatabase.catalog}, database=${discoveredDatabase.database}"
                     )
 
-                    cleanupAuditTableService.writeAuditRecord(
-                        CleanupAuditRecord(
-                            sparkAppId = cleanupAuditTableService.currentSparkAppId(),
-                            runId = runId,
-                            initiatedBy = cleanupAuditTableService.currentSparkUser(),
-                            catalogName = discoveredDatabase.catalog,
-                            databaseName = discoveredDatabase.database,
-                            operation = OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS,
-                            dryRun = config.dryRun,
-                            deleteEnabled = config.deleteEnabled,
-                            status = STATUS_SKIPPED,
-                            discoveredDatabaseLocation = discoveredDatabase.location,
-                            storageScanLocation = "",
-                            activeTableCount = discoveredDatabase.tables.size.toLong(),
-                            storageFolderCount = 0,
-                            candidateFolderCount = 0,
-                            deletedFolderCount = 0,
-                            candidateFolders = emptyList(),
-                            deletedFolders = emptyList(),
-                            excludedPaths = config.excludePaths.sorted(),
-                            metrics =
-                                mapOf(
-                                    "skip_reason" to "database_location_missing",
-                                    "older_than_hours" to config.olderThanHours.toString(),
-                                    "max_candidate_folders_per_database" to
-                                            config.maxCandidateFoldersPerDatabase.toString(),
-                                    "active_table_locations_sample" to
-                                            auditPathSample(
-                                                discoveredDatabase.tables
-                                                    .mapNotNull { it.location }
-                                                    .sorted()
-                                            ),
-                                    "active_table_locations_truncated" to
-                                            isAuditPathSampleTruncated(
-                                                discoveredDatabase.tables
-                                                    .mapNotNull { it.location }
-                                                    .sorted()
-                                            ).toString(),
-                                ),
-                            errorMessage =
-                                "Database location is missing; storage folder discovery was skipped.",
-                            startTime = databaseStartTime,
-                            endTime = Instant.now(),
-                        )
+                    writeDatabaseLocationMissingAuditRecord(
+                        runId = runId,
+                        databaseStartTime = databaseStartTime,
+                        catalogName = discoveredDatabase.catalog,
+                        databaseName = discoveredDatabase.database,
+                        discoveredDatabaseLocation = discoveredDatabase.location,
+                        activeTableCount = discoveredDatabase.tables.size.toLong(),
+                        activeTableLocations =
+                            discoveredDatabase.tables
+                                .mapNotNull { it.location }
+                                .sorted(),
                     )
                 } else {
                     val storageScanLocation =
@@ -150,7 +111,6 @@ class CleanupUntrackedTableFoldersService {
 
                     val candidateFolders =
                         try {
-
                             untrackedFolderCandidateDetector.detectCandidates(
                                 storageFolders = storageFolders,
                                 activeTableLocations =
@@ -167,47 +127,20 @@ class CleanupUntrackedTableFoldersService {
                             )
                             val candidateFolderPaths = th.candidateFolderPaths.sorted()
 
-                            cleanupAuditTableService.writeAuditRecord(
-                                CleanupAuditRecord(
-                                    sparkAppId = cleanupAuditTableService.currentSparkAppId(),
-                                    runId = runId,
-                                    initiatedBy = cleanupAuditTableService.currentSparkUser(),
-                                    catalogName = discoveredDatabase.catalog,
-                                    databaseName = discoveredDatabase.database,
-                                    operation = OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS,
-                                    dryRun = config.dryRun,
-                                    deleteEnabled = config.deleteEnabled,
-                                    status = STATUS_SKIPPED,
-                                    discoveredDatabaseLocation = discoveredDatabase.location,
-                                    storageScanLocation = storageScanLocation,
-                                    activeTableCount = activeTableLocations.size.toLong(),
-                                    storageFolderCount = storageFolderPaths.size.toLong(),
-                                    candidateFolderCount = th.candidateCount.toLong(),
-                                    deletedFolderCount = 0,
-                                    candidateFolders = candidateFolderPaths.take(MAX_AUDIT_PATH_SAMPLE_SIZE),
-                                    deletedFolders = emptyList(),
-                                    excludedPaths = config.excludePaths.sorted(),
-                                    metrics =
-                                        mapOf(
-                                            "skip_reason" to "too_many_candidate_folders",
-                                            "older_than_hours" to config.olderThanHours.toString(),
-                                            "max_candidate_folders_per_database" to
-                                                    config.maxCandidateFoldersPerDatabase.toString(),
-                                            "cutoff_time" to cutoffTime.toString(),
-                                            "active_table_locations_sample" to auditPathSample(activeTableLocations),
-                                            "active_table_locations_truncated" to
-                                                    isAuditPathSampleTruncated(activeTableLocations).toString(),
-                                            "storage_folder_paths_sample" to auditPathSample(storageFolderPaths),
-                                            "storage_folder_paths_truncated" to
-                                                    isAuditPathSampleTruncated(storageFolderPaths).toString(),
-                                            "candidate_folder_paths_sample" to auditPathSample(candidateFolderPaths),
-                                            "candidate_folder_paths_truncated" to
-                                                    isAuditPathSampleTruncated(candidateFolderPaths).toString(),
-                                        ),
-                                    errorMessage = th.message,
-                                    startTime = databaseStartTime,
-                                    endTime = Instant.now(),
-                                )
+                            writeTooManyCandidateFoldersAuditRecord(
+                                runId = runId,
+                                databaseStartTime = databaseStartTime,
+                                catalogName = discoveredDatabase.catalog,
+                                databaseName = discoveredDatabase.database,
+                                discoveredDatabaseLocation = discoveredDatabase.location,
+                                storageScanLocation = storageScanLocation,
+                                activeTableCount = discoveredDatabase.tables.size.toLong(),
+                                activeTableLocations = activeTableLocations,
+                                storageFolderPaths = storageFolderPaths,
+                                candidateFolderPaths = candidateFolderPaths,
+                                candidateCount = th.candidateCount.toLong(),
+                                cutoffTime = cutoffTime,
+                                errorMessage = th.message,
                             )
 
                             return@forEach
@@ -291,55 +224,19 @@ class CleanupUntrackedTableFoldersService {
                         deletedFolderPaths = deletedFolders,
                     )
 
-                    cleanupAuditTableService.writeAuditRecord(
-                        CleanupAuditRecord(
-                            sparkAppId = cleanupAuditTableService.currentSparkAppId(),
-                            runId = runId,
-                            initiatedBy = cleanupAuditTableService.currentSparkUser(),
-                            catalogName = discoveredDatabase.catalog,
-                            databaseName = discoveredDatabase.database,
-                            operation = OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS,
-                            dryRun = config.dryRun,
-                            deleteEnabled = config.deleteEnabled,
-                            status = STATUS_SUCCESS,
-                            discoveredDatabaseLocation = discoveredDatabase.location,
-                            storageScanLocation = storageScanLocation,
-                            activeTableCount = activeTableLocations.size.toLong(),
-                            storageFolderCount = storageFolderPaths.size.toLong(),
-                            candidateFolderCount = candidateFolderPaths.size.toLong(),
-                            deletedFolderCount = deletedFolders.size.toLong(),
-                            candidateFolders = candidateFolderPaths,
-                            deletedFolders = deletedFolders,
-                            excludedPaths = config.excludePaths.sorted(),
-                            metrics =
-                                mapOf(
-                                    "older_than_hours" to config.olderThanHours.toString(),
-                                    "max_candidate_folders_per_database" to
-                                            config.maxCandidateFoldersPerDatabase.toString(),
-                                    "cutoff_time" to cutoffTime.toString(),
-                                    "active_table_locations_sample" to auditPathSample(activeTableLocations),
-                                    "active_table_locations_truncated" to
-                                            isAuditPathSampleTruncated(activeTableLocations).toString(),
-                                    "storage_folder_paths_sample" to auditPathSample(storageFolderPaths),
-                                    "storage_folder_paths_truncated" to
-                                            isAuditPathSampleTruncated(storageFolderPaths).toString(),
-                                    "non_candidate_storage_folder_paths_sample" to
-                                            auditPathSample(
-                                                storageFolderPaths
-                                                    .filter { it !in candidateFolderPaths.toSet() }
-                                                    .sorted()
-                                            ),
-                                    "non_candidate_storage_folder_paths_truncated" to
-                                            isAuditPathSampleTruncated(
-                                                storageFolderPaths
-                                                    .filter { it !in candidateFolderPaths.toSet() }
-                                                    .sorted()
-                                            ).toString(),
-                                ),
-                            errorMessage = null,
-                            startTime = databaseStartTime,
-                            endTime = Instant.now(),
-                        )
+                    writeSuccessAuditRecord(
+                        runId = runId,
+                        databaseStartTime = databaseStartTime,
+                        catalogName = discoveredDatabase.catalog,
+                        databaseName = discoveredDatabase.database,
+                        discoveredDatabaseLocation = discoveredDatabase.location,
+                        storageScanLocation = storageScanLocation,
+                        activeTableCount = discoveredDatabase.tables.size.toLong(),
+                        activeTableLocations = activeTableLocations,
+                        storageFolderPaths = storageFolderPaths,
+                        candidateFolderPaths = candidateFolderPaths,
+                        deletedFolderPaths = deletedFolders,
+                        cutoffTime = cutoffTime,
                     )
                 }
             } catch (th: Throwable) {
@@ -365,6 +262,10 @@ class CleanupUntrackedTableFoldersService {
         }
     }
 
+    private fun logBlankLines(count: Int) {
+        repeat(count) { logger.info("") }
+    }
+
     private fun logCleanupSummary(
         catalog: String,
         database: String,
@@ -375,63 +276,31 @@ class CleanupUntrackedTableFoldersService {
         candidateFolderPaths: List<String>,
         deletedFolderPaths: List<String>,
     ) {
-
         val candidateFolderSet = candidateFolderPaths.toSet()
-
         val protectedFolderPaths = activeTableLocations.toSet()
-
         val nonCandidateStorageFolderPaths =
             storageFolderPaths.filter { it !in candidateFolderSet }.sorted()
-        logger.info("")
-
-        logger.info("")
-
-        logger.info("")
-
+        logBlankLines(3)
         logger.info("========== Cleanup Untracked Table Folders Summary ==========")
-
         logger.info("Catalog: $catalog")
-
         logger.info("Configured database: $database")
-
         logger.info("Discovered database location: $discoveredDatabaseLocation")
-
         logger.info("Object storage scan root: $storageScanLocation")
-
-        logger.info("Catalog active table location count: ${activeTableLocations.size}")
-
+        logger.info("Protected catalog active table location count: ${activeTableLocations.size}")
         logger.info("Immediate child storage folders scanned: ${storageFolderPaths.size}")
-
         logger.info("Untracked candidate folder count: ${candidateFolderPaths.size}")
-
-        logger.info("Deleted folder count: ${deletedFolderPaths.size}")
-
+        logger.info("Deleted untracked folder count: ${deletedFolderPaths.size}")
         logger.info("Deletion performed: ${deletedFolderPaths.isNotEmpty()}")
-
         logger.info("Protected catalog active table locations:")
-
         logListOrNone(protectedFolderPaths.sorted())
-
         logger.info("Storage folders not selected as candidates:")
-
         logListOrNone(nonCandidateStorageFolderPaths)
-
         logger.info("Untracked candidate folders selected for cleanup:")
-
         logListOrNone(candidateFolderPaths)
-
         logger.info("Deleted folders:")
-
         logListOrNone(deletedFolderPaths)
-
         logger.info("============================================================")
-
-        logger.info("")
-
-        logger.info("")
-
-        logger.info("")
-
+        logBlankLines(3)
     }
 
     private fun logListOrNone(values: List<String>) {
@@ -454,43 +323,213 @@ class CleanupUntrackedTableFoldersService {
     private fun isAuditPathSampleTruncated(paths: List<String>): Boolean =
         paths.size > MAX_AUDIT_PATH_SAMPLE_SIZE
 
+    private fun writeDatabaseLocationMissingAuditRecord(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        discoveredDatabaseLocation: String?,
+        activeTableCount: Long,
+        activeTableLocations: List<String>,
+    ) {
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = catalogName,
+            databaseName = databaseName,
+            status = STATUS_SKIPPED,
+            statusReason = "database_location_missing",
+            errorMessage = "Database location is missing; storage folder discovery was skipped.",
+            discoveredDatabaseLocation = discoveredDatabaseLocation,
+            activeTableCount = activeTableCount,
+            diagnosticDetails = diagnosticDetails(activeTableLocations = activeTableLocations),
+        )
+    }
+
+    private fun writeTooManyCandidateFoldersAuditRecord(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        discoveredDatabaseLocation: String?,
+        storageScanLocation: String,
+        activeTableCount: Long,
+        activeTableLocations: List<String>,
+        storageFolderPaths: List<String>,
+        candidateFolderPaths: List<String>,
+        candidateCount: Long,
+        cutoffTime: Instant,
+        errorMessage: String?,
+    ) {
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = catalogName,
+            databaseName = databaseName,
+            status = STATUS_SKIPPED,
+            statusReason = "too_many_candidate_folders",
+            errorMessage = errorMessage,
+            discoveredDatabaseLocation = discoveredDatabaseLocation,
+            storageScanLocation = storageScanLocation,
+            activeTableCount = activeTableCount,
+            storageFolderCount = storageFolderPaths.size.toLong(),
+            candidateFolderCount = candidateCount,
+            candidateFolders = candidateFolderPaths.take(MAX_AUDIT_PATH_SAMPLE_SIZE),
+            cutoffTime = cutoffTime,
+            diagnosticDetails =
+                diagnosticDetails(
+                    activeTableLocations = activeTableLocations,
+                    storageFolderPaths = storageFolderPaths,
+                    candidateFolderPaths = candidateFolderPaths,
+                ),
+        )
+    }
+
+    private fun writeSuccessAuditRecord(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        discoveredDatabaseLocation: String?,
+        storageScanLocation: String,
+        activeTableCount: Long,
+        activeTableLocations: List<String>,
+        storageFolderPaths: List<String>,
+        candidateFolderPaths: List<String>,
+        deletedFolderPaths: List<String>,
+        cutoffTime: Instant,
+    ) {
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = catalogName,
+            databaseName = databaseName,
+            status = STATUS_SUCCESS,
+            statusReason = null,
+            errorMessage = null,
+            discoveredDatabaseLocation = discoveredDatabaseLocation,
+            storageScanLocation = storageScanLocation,
+            activeTableCount = activeTableCount,
+            storageFolderCount = storageFolderPaths.size.toLong(),
+            candidateFolderCount = candidateFolderPaths.size.toLong(),
+            deletedFolderCount = deletedFolderPaths.size.toLong(),
+            candidateFolders = candidateFolderPaths,
+            deletedFolders = deletedFolderPaths,
+            cutoffTime = cutoffTime,
+            diagnosticDetails =
+                diagnosticDetails(
+                    activeTableLocations = activeTableLocations,
+                    storageFolderPaths = storageFolderPaths,
+                    candidateFolderPaths = candidateFolderPaths,
+                    includeNonCandidateStorageFolders = true,
+                ),
+        )
+    }
+
+    private fun diagnosticDetails(
+        activeTableLocations: List<String>,
+        storageFolderPaths: List<String> = emptyList(),
+        candidateFolderPaths: List<String> = emptyList(),
+        includeNonCandidateStorageFolders: Boolean = false,
+    ): Map<String, String> {
+        val details =
+            mutableMapOf(
+                "active_table_locations_sample" to auditPathSample(activeTableLocations),
+                "active_table_locations_truncated" to
+                        isAuditPathSampleTruncated(activeTableLocations).toString(),
+            )
+
+        if (storageFolderPaths.isNotEmpty()) {
+            details["storage_folder_paths_sample"] = auditPathSample(storageFolderPaths)
+            details["storage_folder_paths_truncated"] =
+                isAuditPathSampleTruncated(storageFolderPaths).toString()
+        }
+
+        if (candidateFolderPaths.isNotEmpty()) {
+            details["candidate_folder_paths_sample"] = auditPathSample(candidateFolderPaths)
+            details["candidate_folder_paths_truncated"] =
+                isAuditPathSampleTruncated(candidateFolderPaths).toString()
+        }
+
+        if (includeNonCandidateStorageFolders) {
+            val candidateFolderSet = candidateFolderPaths.toSet()
+            val nonCandidateStorageFolderPaths =
+                storageFolderPaths.filter { it !in candidateFolderSet }.sorted()
+
+            details["non_candidate_storage_folder_paths_sample"] =
+                auditPathSample(nonCandidateStorageFolderPaths)
+            details["non_candidate_storage_folder_paths_truncated"] =
+                isAuditPathSampleTruncated(nonCandidateStorageFolderPaths).toString()
+        }
+
+        return details
+    }
+
+    private fun writeAuditRecord(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        status: String,
+        statusReason: String?,
+        errorMessage: String?,
+        discoveredDatabaseLocation: String? = null,
+        storageScanLocation: String = "",
+        activeTableCount: Long = 0,
+        storageFolderCount: Long = 0,
+        candidateFolderCount: Long = 0,
+        deletedFolderCount: Long = 0,
+        candidateFolders: List<String> = emptyList(),
+        deletedFolders: List<String> = emptyList(),
+        cutoffTime: Instant? = null,
+        diagnosticDetails: Map<String, String> = emptyMap(),
+    ) {
+        cleanupAuditTableService.writeAuditRecord(
+            CleanupAuditRecord(
+                runId = runId,
+                sparkAppId = cleanupAuditTableService.currentSparkAppId(),
+                initiatedBy = cleanupAuditTableService.currentSparkUser(),
+                catalogName = catalogName,
+                databaseName = databaseName,
+                operation = OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS,
+                dryRun = config.dryRun,
+                deleteEnabled = config.deleteEnabled,
+                olderThanHours = config.olderThanHours,
+                cutoffTime = cutoffTime,
+                maxCandidateFoldersPerDatabase = config.maxCandidateFoldersPerDatabase,
+                excludedPaths = config.excludePaths.sorted(),
+                status = status,
+                statusReason = statusReason,
+                errorMessage = errorMessage,
+                discoveredDatabaseLocation = discoveredDatabaseLocation,
+                storageScanLocation = storageScanLocation,
+                activeTableCount = activeTableCount,
+                storageFolderCount = storageFolderCount,
+                candidateFolderCount = candidateFolderCount,
+                deletedFolderCount = deletedFolderCount,
+                candidateFolders = candidateFolders,
+                deletedFolders = deletedFolders,
+                diagnosticDetails = diagnosticDetails,
+                startTime = databaseStartTime,
+                endTime = Instant.now(),
+            )
+        )
+    }
+
     private fun writeFailedAuditRecord(
         runId: String,
         database: String,
         databaseStartTime: Instant,
         error: Throwable,
     ) {
-        cleanupAuditTableService.writeAuditRecord(
-            CleanupAuditRecord(
-                sparkAppId = cleanupAuditTableService.currentSparkAppId(),
-                runId = runId,
-                initiatedBy = cleanupAuditTableService.currentSparkUser(),
-                catalogName = config.catalog,
-                databaseName = database,
-                operation = OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS,
-                dryRun = config.dryRun,
-                deleteEnabled = config.deleteEnabled,
-                status = STATUS_FAILED,
-                discoveredDatabaseLocation = null,
-                storageScanLocation = "",
-                activeTableCount = 0,
-                storageFolderCount = 0,
-                candidateFolderCount = 0,
-                deletedFolderCount = 0,
-                candidateFolders = emptyList(),
-                deletedFolders = emptyList(),
-                excludedPaths = config.excludePaths.sorted(),
-                metrics =
-                    mapOf(
-                        "failure_reason" to (error.message ?: error::class.java.name),
-                        "older_than_hours" to config.olderThanHours.toString(),
-                        "max_candidate_folders_per_database" to
-                                config.maxCandidateFoldersPerDatabase.toString(),
-                    ),
-                errorMessage = error.message ?: error::class.java.name,
-                startTime = databaseStartTime,
-                endTime = Instant.now(),
-            )
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = config.catalog,
+            databaseName = database,
+            status = STATUS_FAILED,
+            statusReason = "unexpected_error",
+            errorMessage = error.message ?: error::class.java.name,
         )
     }
 
@@ -507,7 +546,6 @@ class CleanupUntrackedTableFoldersService {
                     logger.warn(
                         "No active table locations were discovered for databaseLocation=$databaseLocation. Falling back to discovered database location for storage scan. This may miss untracked folders if the database location differs from the actual table storage root."
                     )
-
                     databaseLocation
                 }
                 1 -> inferredScanLocations.single()
@@ -515,7 +553,6 @@ class CleanupUntrackedTableFoldersService {
                     logger.warn(
                         "Multiple active table parent locations were discovered for databaseLocation=$databaseLocation: $inferredScanLocations. Falling back to database location."
                     )
-
                     databaseLocation
                 }
             }
@@ -542,16 +579,12 @@ class CleanupUntrackedTableFoldersService {
     }
 
     private fun parentLocation(location: String): String? {
-
         val normalizedLocation = location.trim().trimEnd('/')
-
         val lastSlashIndex = normalizedLocation.lastIndexOf('/')
 
         return if (lastSlashIndex <= 0) {
-
             null
         } else {
-
             normalizedLocation.substring(0, lastSlashIndex)
         }
     }
@@ -559,13 +592,9 @@ class CleanupUntrackedTableFoldersService {
     private companion object {
 
         const val OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS = "DISCOVER_UNTRACKED_TABLE_FOLDERS"
-
         const val STATUS_SUCCESS = "SUCCESS"
-
         const val STATUS_SKIPPED = "SKIPPED"
-
         const val STATUS_FAILED = "FAILED"
-
         const val MAX_AUDIT_PATH_SAMPLE_SIZE = 100
     }
 }


### PR DESCRIPTION
## Summary

Improves cleanup audit table readability by making important audit values explicit columns and renaming the flexible `metrics` map to `diagnostic_details`.

Changes:
- Adds explicit audit columns for `older_than_hours`, `cutoff_time`, `max_candidate_folders_per_database`, and `status_reason`
- Renames `metrics` to `diagnostic_details` to avoid confusion with Spark/Iceberg metrics
- Reorders audit columns by logical grouping for easier inspection
- Centralizes `CleanupAuditRecord` construction so audit schema fields are written in one place
- Keeps diagnostic path samples and truncation flags in `diagnostic_details`

## Testing

- `./gradlew clean test`
- `./gradlew clean quarkusBuild`

## Follow-up

Two follow-ups are planned after this PR:
- Update the README once the README branch is merged/rebased, so the docs reference the final audit fields such as `status_reason` and `diagnostic_details`.
- Extract audit-writing helpers into a dedicated audit writer in a separate refactor PR, keeping this PR focused on audit schema/readability changes.

## Runtime note

Because the audit table schema changed, existing dev audit tables should be dropped before runtime testing so the job can recreate the table with the new schema.

```sql
DROP TABLE IF EXISTS spark_catalog.iomete_system_db.cleanup_untracked_table_folder_runs;