### PR TITLE
Add cleanup audit SQL tests

### DIFF
--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditTableService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditTableService.kt
@@ -58,66 +58,67 @@ class CleanupAuditTableService {
             "Writing cleanup audit record for runId=${record.runId}, catalog=${record.catalogName}, database=${record.databaseName}, status=${record.status}"
         )
 
-        sparkSessionProvider.getOrCreate().sql(
-            """
-            INSERT INTO $AUDIT_TABLE_NAME (
-              run_id,
-              spark_app_id,
-              initiated_by,
-              catalog_name,
-              database_name,
-              operation,
-              dry_run,
-              delete_enabled,
-              older_than_hours,
-              cutoff_time,
-              max_candidate_folders_per_database,
-              excluded_paths,
-              status,
-              status_reason,
-              error_message,
-              discovered_database_location,
-              storage_scan_location,
-              active_table_count,
-              storage_folder_count,
-              candidate_folder_count,
-              deleted_folder_count,
-              candidate_folders,
-              deleted_folders,
-              diagnostic_details,
-              start_time,
-              end_time
-            )
-            SELECT
-              ${sqlString(record.runId)} AS run_id,
-              ${sqlNullableString(record.sparkAppId)} AS spark_app_id,
-              ${sqlNullableString(record.initiatedBy)} AS initiated_by,
-              ${sqlString(record.catalogName)} AS catalog_name,
-              ${sqlString(record.databaseName)} AS database_name,
-              ${sqlString(record.operation)} AS operation,
-              ${record.dryRun} AS dry_run,
-              ${record.deleteEnabled} AS delete_enabled,
-              ${record.olderThanHours}L AS older_than_hours,
-              ${sqlNullableTimestamp(record.cutoffTime)} AS cutoff_time,
-              ${record.maxCandidateFoldersPerDatabase} AS max_candidate_folders_per_database,
-              ${sqlStringArray(record.excludedPaths)} AS excluded_paths,
-              ${sqlString(record.status)} AS status,
-              ${sqlNullableString(record.statusReason)} AS status_reason,
-              ${sqlNullableString(record.errorMessage)} AS error_message,
-              ${sqlNullableString(record.discoveredDatabaseLocation)} AS discovered_database_location,
-              ${sqlString(record.storageScanLocation)} AS storage_scan_location,
-              ${record.activeTableCount}L AS active_table_count,
-              ${record.storageFolderCount}L AS storage_folder_count,
-              ${record.candidateFolderCount}L AS candidate_folder_count,
-              ${record.deletedFolderCount}L AS deleted_folder_count,
-              ${sqlStringArray(record.candidateFolders)} AS candidate_folders,
-              ${sqlStringArray(record.deletedFolders)} AS deleted_folders,
-              ${sqlStringMap(record.diagnosticDetails)} AS diagnostic_details,
-              ${sqlTimestamp(record.startTime)} AS start_time,
-              ${sqlTimestamp(record.endTime)} AS end_time
-            """.trimIndent()
-        )
+        sparkSessionProvider.getOrCreate().sql(buildInsertAuditRecordSql(record))
     }
+
+    internal fun buildInsertAuditRecordSql(record: CleanupAuditRecord): String =
+        """
+        INSERT INTO $AUDIT_TABLE_NAME (
+          run_id,
+          spark_app_id,
+          initiated_by,
+          catalog_name,
+          database_name,
+          operation,
+          dry_run,
+          delete_enabled,
+          older_than_hours,
+          cutoff_time,
+          max_candidate_folders_per_database,
+          excluded_paths,
+          status,
+          status_reason,
+          error_message,
+          discovered_database_location,
+          storage_scan_location,
+          active_table_count,
+          storage_folder_count,
+          candidate_folder_count,
+          deleted_folder_count,
+          candidate_folders,
+          deleted_folders,
+          diagnostic_details,
+          start_time,
+          end_time
+        )
+        SELECT
+          ${sqlString(record.runId)} AS run_id,
+          ${sqlNullableString(record.sparkAppId)} AS spark_app_id,
+          ${sqlNullableString(record.initiatedBy)} AS initiated_by,
+          ${sqlString(record.catalogName)} AS catalog_name,
+          ${sqlString(record.databaseName)} AS database_name,
+          ${sqlString(record.operation)} AS operation,
+          ${record.dryRun} AS dry_run,
+          ${record.deleteEnabled} AS delete_enabled,
+          ${record.olderThanHours}L AS older_than_hours,
+          ${sqlNullableTimestamp(record.cutoffTime)} AS cutoff_time,
+          ${record.maxCandidateFoldersPerDatabase} AS max_candidate_folders_per_database,
+          ${sqlStringArray(record.excludedPaths)} AS excluded_paths,
+          ${sqlString(record.status)} AS status,
+          ${sqlNullableString(record.statusReason)} AS status_reason,
+          ${sqlNullableString(record.errorMessage)} AS error_message,
+          ${sqlNullableString(record.discoveredDatabaseLocation)} AS discovered_database_location,
+          ${sqlString(record.storageScanLocation)} AS storage_scan_location,
+          ${record.activeTableCount}L AS active_table_count,
+          ${record.storageFolderCount}L AS storage_folder_count,
+          ${record.candidateFolderCount}L AS candidate_folder_count,
+          ${record.deletedFolderCount}L AS deleted_folder_count,
+          ${sqlStringArray(record.candidateFolders)} AS candidate_folders,
+          ${sqlStringArray(record.deletedFolders)} AS deleted_folders,
+          ${sqlStringMap(record.diagnosticDetails)} AS diagnostic_details,
+          ${sqlTimestamp(record.startTime)} AS start_time,
+          ${sqlTimestamp(record.endTime)} AS end_time
+        """.trimIndent()
 
     fun currentSparkAppId(): String? =
         sparkSessionProvider.getOrCreate().sparkContext().applicationId()

--- a/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditTableServiceTest.kt
+++ b/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditTableServiceTest.kt
@@ -1,0 +1,86 @@
+package com.iomete.cleanup.untrackedtablefolders.audit
+
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CleanupAuditTableServiceTest {
+    private val service = CleanupAuditTableService()
+
+    @Test
+    fun `builds audit insert sql with nullable cutoff timestamp`() {
+        val sql =
+            service.buildInsertAuditRecordSql(
+                auditRecord(cutoffTime = null)
+            )
+
+        assertTrue(sql.contains("INSERT INTO ${CleanupAuditTableService.AUDIT_TABLE_NAME} ("))
+        assertTrue(sql.contains("cutoff_time,"))
+        assertTrue(sql.contains("CAST(NULL AS TIMESTAMP) AS cutoff_time"))
+        assertTrue(sql.contains("diagnostic_details"))
+        assertFalse(sql.contains("metrics"))
+    }
+
+    @Test
+    fun `builds audit insert sql with non-null cutoff timestamp`() {
+        val cutoffTime = Instant.parse("2026-05-21T10:15:30Z")
+
+        val sql =
+            service.buildInsertAuditRecordSql(
+                auditRecord(cutoffTime = cutoffTime)
+            )
+
+        assertTrue(sql.contains("TIMESTAMP '"))
+        assertTrue(sql.contains("' AS cutoff_time"))
+        assertFalse(sql.contains("CAST(NULL AS TIMESTAMP) AS cutoff_time"))
+    }
+
+    @Test
+    fun `escapes string values in audit insert sql`() {
+        val sql =
+            service.buildInsertAuditRecordSql(
+                auditRecord(
+                    databaseName = "customer's_db",
+                    errorMessage = "can't find schema",
+                )
+            )
+
+        assertTrue(sql.contains("'customer''s_db' AS database_name"))
+        assertTrue(sql.contains("'can''t find schema' AS error_message"))
+    }
+
+    private fun auditRecord(
+        cutoffTime: Instant? = null,
+        databaseName: String = "test_db",
+        errorMessage: String? = null,
+    ): CleanupAuditRecord =
+        CleanupAuditRecord(
+            runId = "run-1",
+            sparkAppId = "spark-app-1",
+            initiatedBy = "hasan",
+            catalogName = "spark_catalog",
+            databaseName = databaseName,
+            operation = "DISCOVER_UNTRACKED_TABLE_FOLDERS",
+            dryRun = true,
+            deleteEnabled = false,
+            olderThanHours = 24,
+            cutoffTime = cutoffTime,
+            maxCandidateFoldersPerDatabase = 10,
+            excludedPaths = listOf("s3a://bucket/db/protected"),
+            status = "SUCCESS",
+            statusReason = null,
+            errorMessage = errorMessage,
+            discoveredDatabaseLocation = "s3a://bucket/db.db",
+            storageScanLocation = "s3a://bucket/db",
+            activeTableCount = 1,
+            storageFolderCount = 2,
+            candidateFolderCount = 1,
+            deletedFolderCount = 0,
+            candidateFolders = listOf("s3a://bucket/db/orphan"),
+            deletedFolders = emptyList(),
+            diagnosticDetails = mapOf("candidate_folder_paths_truncated" to "false"),
+            startTime = Instant.parse("2026-05-21T10:00:00Z"),
+            endTime = Instant.parse("2026-05-21T10:01:00Z"),
+        )
+}


### PR DESCRIPTION
## Summary

Adds focused unit tests for cleanup audit insert SQL generation.

Changes:
- Extracts audit insert SQL generation into `buildInsertAuditRecordSql`
- Tests nullable `cutoff_time`
- Tests non-null timestamp rendering
- Tests escaping of string values in generated SQL

## Note
- I made it internal so we can unit-test SQL generation directly without needing to create or mock a SparkSession. The production write path still executes the generated SQL through SparkSession.


## Testing

- `./gradlew test`
- `./gradlew clean quarkusBuild`