### PR TITLE
Avoid stack trace for skipped missing database

### DIFF
--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -242,7 +242,10 @@ class CleanupUntrackedTableFoldersService {
                 }
             } catch (th: DatabaseNotFoundException) {
                 logger.warn(
-                    "Configured database was not found; skipping cleanup for catalog=${config.catalog}, database=$database",
+                    "Configured database was not found; skipping cleanup for catalog=${config.catalog}, database=$database"
+                )
+                logger.debug(
+                    "Configured database was not found details for catalog=${config.catalog}, database=$database",
                     th,
                 )
 


### PR DESCRIPTION
## Summary

Avoids printing a full stack trace for the expected missing-database skip path.

Changes:
- Keeps missing configured databases logged as a concise warning
- Moves the full exception details to debug logging
- Preserves the audit behavior: missing database is still recorded as `SKIPPED` with `status_reason=database_not_found`

## Testing

- `./gradlew test`
- `./gradlew clean quarkusBuild`