### PR TITLE
Support database-scoped folder exclusions

### DIFF
--- a/cleanup-untracked-table-folders-job/README.md
+++ b/cleanup-untracked-table-folders-job/README.md
@@ -122,6 +122,7 @@ Example:
   "catalog": "spark_catalog",
   "databases": ["example_database"],
   "exclude_paths": [],
+  "exclude_database_folders": [],
   "older_than_hours": 24,
   "dry_run": true,
   "delete_enabled": false,
@@ -189,17 +190,72 @@ Exact physical object-storage folder paths that should be protected from cleanup
 ]
 ```
 
-`exclude_paths` is intentionally path-based. It does **not** accept table names, catalog identifiers, partial paths, or substring matches in this version.
+`exclude_paths` is intentionally path-based. It does **not** accept table names, catalog identifiers, partial paths, or substring matches.
+
+For a shorter database-scoped exclusion format, use `exclude_database_folders`.
 
 | Input | Supported? | Notes |
 |---|---:|---|
 | `s3a://bucket/data/analytics/customer_events` | Yes | Exact physical storage path |
 | `s3a://bucket/data/analytics/customer_events/` | Yes | Trailing slash is normalized |
 | `customer_events` | No | Table/folder name alone is ambiguous across databases |
-| `analytics.customer_events` | No | This job protects physical folders, not catalog identifiers |
+| `analytics.customer_events` | No for `exclude_paths` | Use `exclude_database_folders` for this database-scoped folder format |
 | `customer` as a substring | No | Substring matching is intentionally not supported |
 
-This is intentional. Full paths are explicit and avoid ambiguous behavior when multiple configured databases contain folders with the same table or folder name.
+Full paths are the most explicit option and avoid ambiguity when multiple configured databases contain folders with the same table or folder name.
+
+---
+
+### `exclude_database_folders`
+
+Database-scoped immediate child folders that should be protected from cleanup.
+
+```json
+"exclude_database_folders": [
+  "analytics.customer_events"
+]
+```
+
+Each entry uses this format:
+
+```text
+<database>.<folder>
+```
+
+For example, if the resolved scan root for database `analytics` is:
+
+```text
+s3a://bucket/data/analytics
+```
+
+then this config:
+
+```json
+"exclude_database_folders": ["analytics.customer_events"]
+```
+
+is internally resolved to this protected physical path:
+
+```text
+s3a://bucket/data/analytics/customer_events
+```
+
+This is useful when operators know the database and folder name but do not want to provide the full object-storage path.
+
+Rules:
+
+- The database part must be listed in `databases`.
+- The folder part must be an immediate child folder name.
+- The folder part must not contain `/`.
+- Catalog prefixes are not supported in this field.
+- The entry is converted to a full physical path internally and then handled together with `exclude_paths`.
+
+| Input | Supported? | Notes |
+|---|---:|---|
+| `analytics.customer_events` | Yes | Protects the `customer_events` folder under the resolved scan root for database `analytics` |
+| `spark_catalog.analytics.customer_events` | No | Catalog prefix is not supported; `catalog` is already configured separately |
+| `customer_events` | No | Database name is required to avoid ambiguity |
+| `analytics.customer_events/nested` | No | Only immediate child folders are supported |
 
 ---
 
@@ -295,6 +351,7 @@ The job has several independent fail-safe layers. These are intentionally redund
 - Deletion requires both `dry_run=false` and `delete_enabled=true`; changing only one flag cannot delete data.
 - Only immediate child folders under the resolved scan root are considered.
 - Active catalog table locations are protected.
+- Configured `exclude_paths` and `exclude_database_folders` are protected.
 - Candidate folders must satisfy `older_than_hours`.
 - Candidate count is capped by `max_candidate_folders_per_database`.
 - Candidate folders are revalidated against active catalog table locations before deletion.
@@ -313,6 +370,7 @@ The main safety principle is **fail closed**: if the job cannot prove that a fol
 | Immediate-child-folder scan only | Recursive scanning of arbitrary nested files |
 | Scan-root boundary validation | Scanning outside the intended database storage area |
 | Active table location protection | Deleting folders still claimed by the catalog |
+| Configured exclusions | Deleting folders explicitly protected through `exclude_paths` or `exclude_database_folders` |
 | `older_than_hours` cutoff | Selecting very recent folders too quickly |
 | `max_candidate_folders_per_database` | Broad accidental deletion when too many candidates appear |
 | Pre-delete catalog revalidation | Deleting a folder that became active after initial discovery |
@@ -454,6 +512,7 @@ Example:
   "catalog": "spark_catalog",
   "databases": ["valid_database", "this_does_not_exist"],
   "exclude_paths": [],
+  "exclude_database_folders": [],
   "older_than_hours": 24,
   "dry_run": true,
   "delete_enabled": false,
@@ -481,6 +540,7 @@ The missing database is logged as a warning, not as a cleanup failure. Unexpecte
   "catalog": "spark_catalog",
   "databases": ["analytics"],
   "exclude_paths": [],
+  "exclude_database_folders": [],
   "older_than_hours": 24,
   "dry_run": true,
   "delete_enabled": false,
@@ -504,6 +564,7 @@ Before enabling deletion, verify that each candidate folder:
 - Is no longer claimed by the catalog.
 - Is older than the configured cutoff.
 - Is not in `exclude_paths`.
+- Is not protected by `exclude_database_folders`.
 - Is expected to be removed.
 - Is not an active table folder recreated at the same location.
 
@@ -514,6 +575,7 @@ Before enabling deletion, verify that each candidate folder:
   "catalog": "spark_catalog",
   "databases": ["analytics"],
   "exclude_paths": [],
+  "exclude_database_folders": [],
   "older_than_hours": 24,
   "dry_run": false,
   "delete_enabled": true,
@@ -540,6 +602,7 @@ Before enabling deletion mode, run the job in dry-run mode and validate the outp
 | T07 | `dry_run=false`, `delete_enabled=false` | Fails safe, no deletion |
 | T08 | Candidate count exceeds max limit | `SKIPPED`, no deletion |
 | T09 | Candidate is listed in `exclude_paths` by full path | Candidate is protected |
+| T09b | Candidate is listed in `exclude_database_folders` as `database.folder` | Candidate is protected |
 | T10 | Loose file directly under scan root | Ignored, not deleted |
 | T11 | Table is dropped then recreated at same location | Folder is protected because it is active again |
 | T12 | Table is dropped then recreated at different location | Old untracked folder can become a candidate |
@@ -636,8 +699,10 @@ Any old unreferenced files inside that active table folder should be handled by 
 ## Known limitations
 
 - `exclude_paths` supports full physical storage paths only.
-- Table names or folder names alone are not supported in `exclude_paths`.
+- `exclude_database_folders` supports database-scoped immediate child folder names in `database.folder` format.
+- Table names or folder names alone are not supported because they can be ambiguous across databases.
 - The job deletes whole untracked table folders, not individual orphan files inside active Iceberg table folders.
-- The job lists immediate child folders under the resolved scan root, not a recursive file tree.
+- Candidate discovery is table-folder-level: the job only selects immediate child folders under the resolved scan root as cleanup candidates.
+- When a selected candidate folder is deleted, the full object-storage prefix under that folder is deleted, including nested data and metadata objects.
 - The job relies on Spark catalog discovery for active table locations.
 - The job is intended for controlled cleanup workflows, not blind automatic deletion.

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/config/Config.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/config/Config.kt
@@ -20,6 +20,9 @@ data class ApplicationConfig(
     @field:JsonProperty("exclude_paths")
     val excludePaths: List<String> = emptyList(),
 
+    @field:JsonProperty("exclude_database_folders")
+    val excludeDatabaseFolders: List<String> = emptyList(),
+
     @field:JsonProperty("older_than_hours")
     val olderThanHours: Long = 24,
 
@@ -37,6 +40,27 @@ data class ApplicationConfig(
 
         require(databases.isNotEmpty()) {
             "databases must contain at least one database name"
+        }
+
+        val configuredDatabaseSet = databases.toSet()
+
+        excludeDatabaseFolders.forEach { excludedDatabaseFolder ->
+            val parts = excludedDatabaseFolder.split(".")
+
+            require(parts.size == 2 && parts[0].isNotBlank() && parts[1].isNotBlank()) {
+                "exclude_database_folders entries must use database.folder format: $excludedDatabaseFolder"
+            }
+
+            val database = parts[0]
+            val folder = parts[1]
+
+            require(database in configuredDatabaseSet) {
+                "exclude_database_folders database must be listed in databases: $excludedDatabaseFolder"
+            }
+
+            require('/' !in folder) {
+                "exclude_database_folders folder must be an immediate child folder name without '/': $excludedDatabaseFolder"
+            }
         }
 
         require(olderThanHours >= 0) {

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -37,7 +37,7 @@ class CleanupUntrackedTableFoldersService {
 
         config.databases.forEach { database ->
             val databaseStartTime = Instant.now()
-
+            var effectiveExcludedPathsForAudit = normalizedConfiguredExcludePaths()
             try {
                 val discoveredDatabase =
                     catalogDiscoveryService.discoverDatabase(
@@ -108,6 +108,23 @@ class CleanupUntrackedTableFoldersService {
                     val activeTableLocations =
                         discoveredDatabase.tables.mapNotNull { it.location }.sorted()
 
+                    val effectiveExcludedPaths =
+                        effectiveExcludedPaths(
+                            database = discoveredDatabase.database,
+                            storageScanLocation = storageScanLocation,
+                        )
+
+                    effectiveExcludedPathsForAudit = effectiveExcludedPaths
+
+                    if (effectiveExcludedPaths.isNotEmpty()) {
+                        logger.info(
+                            "Using ${effectiveExcludedPaths.size} effective excluded path(s) for catalog=${discoveredDatabase.catalog}, database=${discoveredDatabase.database}"
+                        )
+                        effectiveExcludedPaths.forEach { excludedPath ->
+                            logger.info("Effective excluded path: $excludedPath")
+                        }
+                    }
+
                     val storageFolderPaths = storageFolders.map { it.path }.sorted()
 
                     val candidateFolders =
@@ -116,7 +133,7 @@ class CleanupUntrackedTableFoldersService {
                                 storageFolders = storageFolders,
                                 activeTableLocations =
                                     discoveredDatabase.tables.mapNotNull { it.location },
-                                excludedPaths = config.excludePaths,
+                                excludedPaths = effectiveExcludedPaths,
                                 cutoffTimeMillis = cutoffTimeMillis,
                                 maxCandidateFolders = config.maxCandidateFoldersPerDatabase,
                             )
@@ -141,6 +158,7 @@ class CleanupUntrackedTableFoldersService {
                                 candidateFolderPaths = candidateFolderPaths,
                                 candidateCount = th.candidateCount.toLong(),
                                 cutoffTime = cutoffTime,
+                                excludedPaths = effectiveExcludedPaths,
                                 errorMessage = th.message,
                             )
 
@@ -221,6 +239,7 @@ class CleanupUntrackedTableFoldersService {
                         storageScanLocation = storageScanLocation,
                         activeTableLocations = activeTableLocations,
                         storageFolderPaths = storageFolderPaths,
+                        excludedPaths = effectiveExcludedPaths,
                         candidateFolderPaths = candidateFolderPaths,
                         deletedFolderPaths = deletedFolders,
                     )
@@ -238,6 +257,7 @@ class CleanupUntrackedTableFoldersService {
                         candidateFolderPaths = candidateFolderPaths,
                         deletedFolderPaths = deletedFolders,
                         cutoffTime = cutoffTime,
+                        excludedPaths = effectiveExcludedPaths,
                     )
                 }
             } catch (th: DatabaseNotFoundException) {
@@ -262,6 +282,7 @@ class CleanupUntrackedTableFoldersService {
                     runId = runId,
                     database = database,
                     databaseStartTime = databaseStartTime,
+                    excludedPaths = effectiveExcludedPathsForAudit,
                     error = th,
                 )
             }
@@ -289,6 +310,7 @@ class CleanupUntrackedTableFoldersService {
         storageScanLocation: String,
         activeTableLocations: List<String>,
         storageFolderPaths: List<String>,
+        excludedPaths: List<String>,
         candidateFolderPaths: List<String>,
         deletedFolderPaths: List<String>,
     ) {
@@ -309,6 +331,8 @@ class CleanupUntrackedTableFoldersService {
         logger.info("Deletion performed: ${deletedFolderPaths.isNotEmpty()}")
         logger.info("Protected catalog active table locations:")
         logListOrNone(protectedFolderPaths.sorted())
+        logger.info("Effective excluded paths:")
+        logListOrNone(excludedPaths.sorted())
         logger.info("Storage folders not selected as candidates:")
         logListOrNone(nonCandidateStorageFolderPaths)
         logger.info("Untracked candidate folders selected for cleanup:")
@@ -375,6 +399,7 @@ class CleanupUntrackedTableFoldersService {
         candidateFolderPaths: List<String>,
         candidateCount: Long,
         cutoffTime: Instant,
+        excludedPaths: List<String>,
         errorMessage: String?,
     ) {
         writeAuditRecord(
@@ -392,6 +417,7 @@ class CleanupUntrackedTableFoldersService {
             candidateFolderCount = candidateCount,
             candidateFolders = candidateFolderPaths.take(MAX_AUDIT_PATH_SAMPLE_SIZE),
             cutoffTime = cutoffTime,
+            excludedPaths = excludedPaths,
             diagnosticDetails =
                 diagnosticDetails(
                     activeTableLocations = activeTableLocations,
@@ -414,6 +440,7 @@ class CleanupUntrackedTableFoldersService {
         candidateFolderPaths: List<String>,
         deletedFolderPaths: List<String>,
         cutoffTime: Instant,
+        excludedPaths: List<String>,
     ) {
         writeAuditRecord(
             runId = runId,
@@ -432,6 +459,7 @@ class CleanupUntrackedTableFoldersService {
             candidateFolders = candidateFolderPaths,
             deletedFolders = deletedFolderPaths,
             cutoffTime = cutoffTime,
+            excludedPaths = excludedPaths,
             diagnosticDetails =
                 diagnosticDetails(
                     activeTableLocations = activeTableLocations,
@@ -498,6 +526,7 @@ class CleanupUntrackedTableFoldersService {
         candidateFolders: List<String> = emptyList(),
         deletedFolders: List<String> = emptyList(),
         cutoffTime: Instant? = null,
+        excludedPaths: List<String> = config.excludePaths,
         diagnosticDetails: Map<String, String> = emptyMap(),
     ) {
         cleanupAuditTableService.writeAuditRecord(
@@ -513,7 +542,7 @@ class CleanupUntrackedTableFoldersService {
                 olderThanHours = config.olderThanHours,
                 cutoffTime = cutoffTime,
                 maxCandidateFoldersPerDatabase = config.maxCandidateFoldersPerDatabase,
-                excludedPaths = config.excludePaths.sorted(),
+                excludedPaths = excludedPaths.sorted(),
                 status = status,
                 statusReason = statusReason,
                 errorMessage = errorMessage,
@@ -553,6 +582,7 @@ class CleanupUntrackedTableFoldersService {
         runId: String,
         database: String,
         databaseStartTime: Instant,
+        excludedPaths: List<String> = normalizedConfiguredExcludePaths(),
         error: Throwable,
     ) {
         writeAuditRecord(
@@ -563,8 +593,40 @@ class CleanupUntrackedTableFoldersService {
             status = STATUS_FAILED,
             statusReason = "unexpected_error",
             errorMessage = error.message ?: error::class.java.name,
+            excludedPaths = excludedPaths,
         )
     }
+
+    private fun normalizedConfiguredExcludePaths(): List<String> =
+        config.excludePaths
+            .map { StoragePathUtils.normalizeLocation(it) }
+            .distinct()
+            .sorted()
+
+    private fun effectiveExcludedPaths(
+        database: String,
+        storageScanLocation: String,
+    ): List<String> =
+        (normalizedConfiguredExcludePaths() + resolvedExcludeDatabaseFolderPaths(database, storageScanLocation))
+            .map { StoragePathUtils.normalizeLocation(it) }
+            .distinct()
+            .sorted()
+
+    private fun resolvedExcludeDatabaseFolderPaths(
+        database: String,
+        storageScanLocation: String,
+    ): List<String> =
+        config.excludeDatabaseFolders.mapNotNull { excludedDatabaseFolder ->
+            val parts = excludedDatabaseFolder.split(".")
+            val excludedDatabase = parts[0]
+            val excludedFolder = parts[1]
+
+            if (excludedDatabase == database) {
+                StoragePathUtils.normalizeLocation("$storageScanLocation/$excludedFolder")
+            } else {
+                null
+            }
+        }
 
     private fun resolveStorageScanLocation(
         databaseLocation: String,

--- a/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/candidate/UntrackedFolderCandidateDetectorTest.kt
+++ b/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/candidate/UntrackedFolderCandidateDetectorTest.kt
@@ -47,6 +47,27 @@ class UntrackedFolderCandidateDetectorTest {
     }
 
     @Test
+    fun `excludes resolved database folder paths from candidates`() {
+        val resolvedDatabaseFolderExclusion = "s3a://bucket/db/customer_events"
+
+        val candidates = detector.detectCandidates(
+            storageFolders = listOf(
+                storageFolder("s3a://bucket/db/customer_events", modificationTimeMillis = 100),
+                storageFolder("s3a://bucket/db/deleted_table", modificationTimeMillis = 100),
+            ),
+            activeTableLocations = emptyList(),
+            excludedPaths = listOf(resolvedDatabaseFolderExclusion),
+            cutoffTimeMillis = 200,
+            maxCandidateFolders = 10,
+        )
+
+        assertEquals(
+            listOf("s3a://bucket/db/deleted_table"),
+            candidates.map { it.path },
+        )
+    }
+
+    @Test
     fun `normalizes trailing slashes before comparing paths`() {
         val candidates = detector.detectCandidates(
             storageFolders = listOf(

--- a/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/config/ConfigTest.kt
+++ b/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/config/ConfigTest.kt
@@ -1,0 +1,62 @@
+package com.iomete.cleanup.untrackedtablefolders.config
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class ConfigTest {
+
+    @Test
+    fun `valid exclude database folders pass validation`() {
+        val config =
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics"),
+                excludeDatabaseFolders = listOf("analytics.customer_events"),
+            )
+
+        assertDoesNotThrow { config.validate() }
+    }
+
+    @Test
+    fun `exclude database folders must use database folder format`() {
+        val config =
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics"),
+                excludeDatabaseFolders = listOf("customer_events"),
+            )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            config.validate()
+        }
+    }
+
+    @Test
+    fun `exclude database folders database must be configured`() {
+        val config =
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics"),
+                excludeDatabaseFolders = listOf("sales.customer_events"),
+            )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            config.validate()
+        }
+    }
+
+    @Test
+    fun `exclude database folders must reference immediate child folder`() {
+        val config =
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics"),
+                excludeDatabaseFolders = listOf("analytics.customer_events/nested"),
+            )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            config.validate()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `exclude_database_folders` as a shorter database-scoped exclusion format.

Changes:
- Adds `exclude_database_folders` config field
- Validates entries use `database.folder` format
- Converts matching entries into full physical paths under the resolved database scan root
- Merges those resolved paths with existing `exclude_paths`
- Logs effective excluded paths in the cleanup summary
- Writes effective excluded paths into audit rows
- Updates README with examples and safety notes
- Adds config and candidate detector tests

## Notes

`exclude_paths` remains supported for exact full physical paths.

`exclude_database_folders` is intended for immediate child folders under a configured database scan root. It does not accept catalog prefixes or nested paths.

## Testing

- `./gradlew test`
- `./gradlew clean quarkusBuild`