### PR TITLE
Update pytest in query scheduler dev requirements

### DIFF
--- a/query-scheduler-job/infra/requirements-dev.txt
+++ b/query-scheduler-job/infra/requirements-dev.txt
@@ -3,4 +3,4 @@ pyhocon~=0.3.59
 
 # dev dependencies
 pyspark==3.3.2
-pytest==9.0.1
+pytest==9.0.3


### PR DESCRIPTION
Updates pytest from 9.0.1 to 9.0.3 in query-scheduler-job dev requirements to address the Dependabot alert.

Validation:
- dependency-only change