### PR TITLE
Update pytest in kinesis streaming dev requirements

### DIFF
--- a/kinesis-streaming-job/infra/requirements-dev.txt
+++ b/kinesis-streaming-job/infra/requirements-dev.txt
@@ -4,6 +4,6 @@ attrs==22.2.0
 
 # dev dependencies
 pyspark==3.3.2
-pytest==7.1.2
+pytest==9.0.3
 boto3
 faker


### PR DESCRIPTION
Updates pytest from 7.1.2 to 9.0.3 in kinesis-streaming-job dev requirements to address the Dependabot alert.

Validation:
- dependency-only change