### PR TITLE
Update pytest in kafka iceberg dev requirements

### DIFF
--- a/kafka-iceberg-stream/infra/requirements-dev.txt
+++ b/kafka-iceberg-stream/infra/requirements-dev.txt
@@ -3,4 +3,4 @@ pyhocon~=0.3.59
 
 # dev dependencies
 pyspark==3.3.3
-pytest==7.1.2
+pytest==9.0.3


### PR DESCRIPTION
Updates pytest from 7.1.2 to 9.0.3 in kafka-iceberg-stream dev requirements to address the Dependabot alert.

Validation:
- dependency-only change