### PR TITLE
Update requests in kubernetes event collector

### DIFF
--- a/kubernetes-event-collector/poetry.lock
+++ b/kubernetes-event-collector/poetry.lock
@@ -1966,25 +1966,26 @@ typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
-    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
+    {file = "requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b"},
+    {file = "requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652"},
 ]
 
 [package.dependencies]
-certifi = ">=2017.4.17"
+certifi = ">=2023.5.7"
 charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
+urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+test = ["PySocks (>=1.5.6,!=1.5.7)", "pytest (>=3)", "pytest-cov", "pytest-httpbin (==2.1.0)", "pytest-mock", "pytest-xdist"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "requests-oauthlib"
@@ -2377,4 +2378,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4"
-content-hash = "a779ec434a3fa65bb4ad0864322fad3f2005ce283fad9d493d8afa4133763ec2"
+content-hash = "60bed1292cfeb0ece5a862bdbe19aa3c54ca142086ac9866be1162ef913ee0d5"

--- a/kubernetes-event-collector/pyproject.toml
+++ b/kubernetes-event-collector/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pyhocon (==0.3.59)",
     "boto3 (>=1.28.0)",
     "kubernetes (>=28.1.0)",
-    "requests (==2.32.5)",
+    "requests (==2.33.0)",
     "pandas (>=2.0.0)",
     "psycopg2-binary (>=2.9.6)",
     "rsa (>=4.7)"


### PR DESCRIPTION
Updates requests from 2.32.5 to 2.33.0 in kubernetes-event-collector to address the Dependabot alert.

Validation:
- poetry check
- poetry install --no-root