### PR TITLE
Update pgjdbc dependency

### DIFF
--- a/debezium-server-iomete/debezium-server-iomete-sinks/pom.xml
+++ b/debezium-server-iomete/debezium-server-iomete-sinks/pom.xml
@@ -107,7 +107,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
-            <version>42.7.7</version>
+            <version>42.7.11</version>
         </dependency>
         <dependency>
             <groupId>org.easytesting</groupId>


### PR DESCRIPTION
Updates pgjdbc from 42.7.7 to 42.7.11 to address the Dependabot alert.

Validation:
- mvn test attempted in debezium-server-iomete-sinks
- Failed locally because Testcontainers could not find a valid Docker environment