### PR TITLE
Refactor cleanup untracked table folders job

### DIFF
--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/AuditConstants.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/AuditConstants.kt
@@ -1,0 +1,11 @@
+package com.iomete.cleanup.untrackedtablefolders.audit
+
+/**
+ * Maximum number of paths included in the audit-table `candidate_folders` array
+ * column and in any `*_sample` entries inside the `diagnostic_details` map.
+ *
+ * Used by [CleanupAuditRecorder] to pre-truncate array columns and by
+ * [CleanupAuditDiagnosticDetailsBuilder] to truncate and flag textual samples.
+ * Both must use the same value so that the audit row is internally consistent.
+ */
+internal const val MAX_AUDIT_PATH_SAMPLE_SIZE = 100

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditDiagnosticDetailsBuilder.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditDiagnosticDetailsBuilder.kt
@@ -1,0 +1,51 @@
+package com.iomete.cleanup.untrackedtablefolders.audit
+
+import jakarta.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+class CleanupAuditDiagnosticDetailsBuilder {
+
+    fun build(
+        activeTableLocations: List<String>,
+        storageFolderPaths: List<String> = emptyList(),
+        candidateFolderPaths: List<String> = emptyList(),
+        nonCandidateStorageFolderPaths: List<String> = emptyList(),
+    ): Map<String, String> {
+        val details = mutableMapOf(
+            "active_table_locations_sample" to auditPathSample(activeTableLocations),
+            "active_table_locations_truncated" to
+                isAuditPathSampleTruncated(activeTableLocations).toString(),
+        )
+
+        if (storageFolderPaths.isNotEmpty()) {
+            details["storage_folder_paths_sample"] = auditPathSample(storageFolderPaths)
+            details["storage_folder_paths_truncated"] =
+                isAuditPathSampleTruncated(storageFolderPaths).toString()
+        }
+
+        if (candidateFolderPaths.isNotEmpty()) {
+            details["candidate_folder_paths_sample"] = auditPathSample(candidateFolderPaths)
+            details["candidate_folder_paths_truncated"] =
+                isAuditPathSampleTruncated(candidateFolderPaths).toString()
+        }
+
+        if (nonCandidateStorageFolderPaths.isNotEmpty()) {
+            details["non_candidate_storage_folder_paths_sample"] =
+                auditPathSample(nonCandidateStorageFolderPaths)
+            details["non_candidate_storage_folder_paths_truncated"] =
+                isAuditPathSampleTruncated(nonCandidateStorageFolderPaths).toString()
+        }
+
+        return details
+    }
+
+    private fun auditPathSample(paths: List<String>): String =
+        paths.take(MAX_AUDIT_PATH_SAMPLE_SIZE).joinToString("\n")
+
+    private fun isAuditPathSampleTruncated(paths: List<String>): Boolean =
+        paths.size > MAX_AUDIT_PATH_SAMPLE_SIZE
+
+    private companion object {
+        const val MAX_AUDIT_PATH_SAMPLE_SIZE = 100
+    }
+}

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditDiagnosticDetailsBuilder.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditDiagnosticDetailsBuilder.kt
@@ -44,8 +44,4 @@ class CleanupAuditDiagnosticDetailsBuilder {
 
     private fun isAuditPathSampleTruncated(paths: List<String>): Boolean =
         paths.size > MAX_AUDIT_PATH_SAMPLE_SIZE
-
-    private companion object {
-        const val MAX_AUDIT_PATH_SAMPLE_SIZE = 100
-    }
 }

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditRecorder.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditRecorder.kt
@@ -1,7 +1,7 @@
 package com.iomete.cleanup.untrackedtablefolders.audit
 
 import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
-import com.iomete.cleanup.untrackedtablefolders.storage.StoragePathUtils
+import com.iomete.cleanup.untrackedtablefolders.storage.ExcludePathResolver
 import com.iomete.cleanup.untrackedtablefolders.storage.StorageSizeStats
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -13,6 +13,7 @@ class CleanupAuditRecorder {
     @Inject lateinit var config: ApplicationConfig
     @Inject lateinit var cleanupAuditTableService: CleanupAuditTableService
     @Inject lateinit var auditDiagnosticDetailsBuilder: CleanupAuditDiagnosticDetailsBuilder
+    @Inject lateinit var excludePathResolver: ExcludePathResolver
 
     fun recordDatabaseLocationMissing(
         runId: String,
@@ -177,7 +178,7 @@ class CleanupAuditRecorder {
         runId: String,
         database: String,
         databaseStartTime: Instant,
-        excludedPaths: List<String> = normalizedConfiguredExcludePaths(),
+        excludedPaths: List<String> = excludePathResolver.normalizedConfiguredExcludePaths(),
         error: Throwable,
     ) {
         writeAuditRecord(
@@ -213,7 +214,7 @@ class CleanupAuditRecorder {
         candidateFolders: List<String> = emptyList(),
         deletedFolders: List<String> = emptyList(),
         cutoffTime: Instant? = null,
-        excludedPaths: List<String> = normalizedConfiguredExcludePaths(),
+        excludedPaths: List<String> = excludePathResolver.normalizedConfiguredExcludePaths(),
         diagnosticDetails: Map<String, String> = emptyMap(),
     ) {
         cleanupAuditTableService.writeAuditRecord(
@@ -256,12 +257,6 @@ class CleanupAuditRecorder {
             )
         )
     }
-
-    private fun normalizedConfiguredExcludePaths(): List<String> =
-        config.excludePaths
-            .map { StoragePathUtils.normalizeLocation(it) }
-            .distinct()
-            .sorted()
 
     private companion object {
         const val OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS = "DISCOVER_UNTRACKED_TABLE_FOLDERS"

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditRecorder.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditRecorder.kt
@@ -1,0 +1,273 @@
+package com.iomete.cleanup.untrackedtablefolders.audit
+
+import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import com.iomete.cleanup.untrackedtablefolders.storage.StoragePathUtils
+import com.iomete.cleanup.untrackedtablefolders.storage.StorageSizeStats
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import java.time.Instant
+
+@ApplicationScoped
+class CleanupAuditRecorder {
+
+    @Inject lateinit var config: ApplicationConfig
+    @Inject lateinit var cleanupAuditTableService: CleanupAuditTableService
+    @Inject lateinit var auditDiagnosticDetailsBuilder: CleanupAuditDiagnosticDetailsBuilder
+
+    fun recordDatabaseLocationMissing(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        discoveredDatabaseLocation: String?,
+        activeTableCount: Long,
+        activeTableLocations: List<String>,
+        errorMessage: String,
+        excludedPaths: List<String>,
+    ) {
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = catalogName,
+            databaseName = databaseName,
+            status = STATUS_SKIPPED,
+            statusReason = "database_location_missing",
+            errorMessage = errorMessage,
+            discoveredDatabaseLocation = discoveredDatabaseLocation,
+            activeTableCount = activeTableCount,
+            excludedPaths = excludedPaths,
+            diagnosticDetails =
+                auditDiagnosticDetailsBuilder.build(activeTableLocations = activeTableLocations),
+        )
+    }
+
+    fun recordNoActiveTables(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        discoveredDatabaseLocation: String?,
+        excludedPaths: List<String>,
+    ) {
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = catalogName,
+            databaseName = databaseName,
+            status = STATUS_SKIPPED,
+            statusReason = "no_active_tables_in_database",
+            errorMessage = "Database has no active table locations; cleanup skipped to avoid deleting an unanchored storage root.",
+            discoveredDatabaseLocation = discoveredDatabaseLocation,
+            activeTableCount = 0,
+            excludedPaths = excludedPaths,
+            diagnosticDetails = auditDiagnosticDetailsBuilder.build(activeTableLocations = emptyList()),
+        )
+    }
+
+    fun recordTooManyCandidateFolders(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        discoveredDatabaseLocation: String?,
+        storageScanLocation: String,
+        activeTableCount: Long,
+        activeTableLocations: List<String>,
+        storageFolderPaths: List<String>,
+        candidateFolderPaths: List<String>,
+        cutoffTime: Instant,
+        excludedPaths: List<String>,
+        errorMessage: String,
+    ) {
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = catalogName,
+            databaseName = databaseName,
+            status = STATUS_SKIPPED,
+            statusReason = "too_many_candidate_folders",
+            errorMessage = errorMessage,
+            discoveredDatabaseLocation = discoveredDatabaseLocation,
+            storageScanLocation = storageScanLocation,
+            activeTableCount = activeTableCount,
+            storageFolderCount = storageFolderPaths.size.toLong(),
+            candidateFolderCount = candidateFolderPaths.size.toLong(),
+            candidateFolders = candidateFolderPaths.take(MAX_AUDIT_PATH_SAMPLE_SIZE),
+            cutoffTime = cutoffTime,
+            excludedPaths = excludedPaths,
+            diagnosticDetails =
+                auditDiagnosticDetailsBuilder.build(
+                    activeTableLocations = activeTableLocations,
+                    storageFolderPaths = storageFolderPaths,
+                    candidateFolderPaths = candidateFolderPaths,
+                ),
+        )
+    }
+
+    fun recordSuccess(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        discoveredDatabaseLocation: String?,
+        storageScanLocation: String,
+        activeTableCount: Long,
+        activeTableLocations: List<String>,
+        storageFolderPaths: List<String>,
+        candidateFolderPaths: List<String>,
+        candidateSizeStats: StorageSizeStats?,
+        deletedFolderPaths: List<String>,
+        deletedSizeStats: StorageSizeStats?,
+        cutoffTime: Instant,
+        excludedPaths: List<String>,
+    ) {
+        val candidateFolderPathSet = candidateFolderPaths.toSet()
+
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = catalogName,
+            databaseName = databaseName,
+            status = STATUS_SUCCESS,
+            statusReason = null,
+            errorMessage = null,
+            discoveredDatabaseLocation = discoveredDatabaseLocation,
+            storageScanLocation = storageScanLocation,
+            activeTableCount = activeTableCount,
+            storageFolderCount = storageFolderPaths.size.toLong(),
+            candidateFolderCount = candidateFolderPaths.size.toLong(),
+            candidateObjectCount = candidateSizeStats?.objectCount,
+            candidateTotalSizeBytes = candidateSizeStats?.totalSizeBytes,
+            deletedFolderCount = deletedFolderPaths.size.toLong(),
+            deletedObjectCount = deletedSizeStats?.objectCount,
+            deletedTotalSizeBytes = deletedSizeStats?.totalSizeBytes,
+            candidateFolders = candidateFolderPaths,
+            deletedFolders = deletedFolderPaths,
+            cutoffTime = cutoffTime,
+            excludedPaths = excludedPaths,
+            diagnosticDetails =
+                auditDiagnosticDetailsBuilder.build(
+                    activeTableLocations = activeTableLocations,
+                    storageFolderPaths = storageFolderPaths,
+                    candidateFolderPaths = candidateFolderPaths,
+                    nonCandidateStorageFolderPaths =
+                        storageFolderPaths.filter { it !in candidateFolderPathSet }.sorted(),
+                ),
+        )
+    }
+
+    fun recordDatabaseNotFound(
+        runId: String,
+        database: String,
+        databaseStartTime: Instant,
+        error: Throwable,
+    ) {
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = config.catalog,
+            databaseName = database,
+            status = STATUS_SKIPPED,
+            statusReason = "database_not_found",
+            errorMessage = error.message ?: error::class.java.name,
+        )
+    }
+
+    fun recordFailed(
+        runId: String,
+        database: String,
+        databaseStartTime: Instant,
+        excludedPaths: List<String> = normalizedConfiguredExcludePaths(),
+        error: Throwable,
+    ) {
+        writeAuditRecord(
+            runId = runId,
+            databaseStartTime = databaseStartTime,
+            catalogName = config.catalog,
+            databaseName = database,
+            status = STATUS_FAILED,
+            statusReason = "unexpected_error",
+            errorMessage = error.message ?: error::class.java.name,
+            excludedPaths = excludedPaths,
+        )
+    }
+
+    private fun writeAuditRecord(
+        runId: String,
+        databaseStartTime: Instant,
+        catalogName: String,
+        databaseName: String,
+        status: String,
+        statusReason: String?,
+        errorMessage: String?,
+        discoveredDatabaseLocation: String? = null,
+        storageScanLocation: String = "",
+        activeTableCount: Long = 0,
+        storageFolderCount: Long = 0,
+        candidateFolderCount: Long = 0,
+        candidateObjectCount: Long? = null,
+        candidateTotalSizeBytes: Long? = null,
+        deletedFolderCount: Long = 0,
+        deletedObjectCount: Long? = null,
+        deletedTotalSizeBytes: Long? = null,
+        candidateFolders: List<String> = emptyList(),
+        deletedFolders: List<String> = emptyList(),
+        cutoffTime: Instant? = null,
+        excludedPaths: List<String> = normalizedConfiguredExcludePaths(),
+        diagnosticDetails: Map<String, String> = emptyMap(),
+    ) {
+        cleanupAuditTableService.writeAuditRecord(
+            CleanupAuditRecord(
+                runId = runId,
+                sparkAppId = cleanupAuditTableService.currentSparkAppId(),
+                runtimeComputeId = cleanupAuditTableService.currentRuntimeComputeId(),
+                runtimeComputeNamespace = cleanupAuditTableService.currentRuntimeComputeNamespace(),
+                runtimeDomain = cleanupAuditTableService.currentRuntimeDomain(),
+                runtimeUser = cleanupAuditTableService.currentRuntimeUser(),
+                externalJobId = cleanupAuditTableService.currentExternalJobId(),
+                platformStartedBy = cleanupAuditTableService.currentPlatformStartedBy(),
+                catalogName = catalogName,
+                databaseName = databaseName,
+                operation = OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS,
+                dryRun = config.dryRun,
+                deleteEnabled = config.deleteEnabled,
+                olderThanHours = config.olderThanHours,
+                cutoffTime = cutoffTime,
+                maxCandidateFoldersPerDatabase = config.maxCandidateFoldersPerDatabase,
+                excludedPaths = excludedPaths.sorted(),
+                status = status,
+                statusReason = statusReason,
+                errorMessage = errorMessage,
+                discoveredDatabaseLocation = discoveredDatabaseLocation,
+                storageScanLocation = storageScanLocation,
+                activeTableCount = activeTableCount,
+                storageFolderCount = storageFolderCount,
+                candidateFolderCount = candidateFolderCount,
+                candidateObjectCount = candidateObjectCount,
+                candidateTotalSizeBytes = candidateTotalSizeBytes,
+                deletedFolderCount = deletedFolderCount,
+                deletedObjectCount = deletedObjectCount,
+                deletedTotalSizeBytes = deletedTotalSizeBytes,
+                candidateFolders = candidateFolders,
+                deletedFolders = deletedFolders,
+                diagnosticDetails = diagnosticDetails,
+                startTime = databaseStartTime,
+                endTime = Instant.now(),
+            )
+        )
+    }
+
+    private fun normalizedConfiguredExcludePaths(): List<String> =
+        config.excludePaths
+            .map { StoragePathUtils.normalizeLocation(it) }
+            .distinct()
+            .sorted()
+
+    private companion object {
+        const val OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS = "DISCOVER_UNTRACKED_TABLE_FOLDERS"
+        const val STATUS_SUCCESS = "SUCCESS"
+        const val STATUS_SKIPPED = "SKIPPED"
+        const val STATUS_FAILED = "FAILED"
+        const val MAX_AUDIT_PATH_SAMPLE_SIZE = 100
+    }
+}

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditRecorder.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditRecorder.kt
@@ -263,6 +263,5 @@ class CleanupAuditRecorder {
         const val STATUS_SUCCESS = "SUCCESS"
         const val STATUS_SKIPPED = "SKIPPED"
         const val STATUS_FAILED = "FAILED"
-        const val MAX_AUDIT_PATH_SAMPLE_SIZE = 100
     }
 }

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/candidate/UntrackedFolderCandidateDetector.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/candidate/UntrackedFolderCandidateDetector.kt
@@ -37,30 +37,22 @@ class UntrackedFolderCandidateDetector {
 
         val candidateFolders = storageFolders
             .filter { storageFolder ->
-                val normalizedFolder = StoragePathUtils.normalizeLocation(storageFolder.path)
-                val finalSegment = normalizedFolder.substringAfterLast('/')
-                val matchedSentinelPrefix = SENTINEL_FOLDER_PREFIXES.firstOrNull { prefix ->
-                    finalSegment.startsWith(prefix)
-                }
-                if (matchedSentinelPrefix != null) {
+                val skipReason =
+                    skipReason(
+                        storageFolder = storageFolder,
+                        normalizedActiveTableLocations = normalizedActiveTableLocations,
+                        excludedPathSet = excludedPathSet,
+                        cutoffTimeMillis = cutoffTimeMillis,
+                    )
+
+                if (skipReason != null) {
                     logger.info(
-                        "Skipping framework sentinel folder (never selected as cleanup candidate): path=${storageFolder.path}, matchedPrefix=$matchedSentinelPrefix"
+                        "Storage folder was not selected as cleanup candidate: path=${storageFolder.path}, reason=${skipReason.logValue}"
                     )
                 }
-                matchedSentinelPrefix == null
+
+                skipReason == null
             }
-            .filter { storageFolder ->
-                val normalizedFolder = StoragePathUtils.normalizeLocation(storageFolder.path)
-                val claimedByActiveTable = normalizedActiveTableLocations.any { activeLocation ->
-                    StoragePathUtils.isSameOrChildLocation(
-                        candidateLocation = activeLocation,
-                        rootLocation = normalizedFolder,
-                    )
-                }
-                !claimedByActiveTable
-            }
-            .filter { StoragePathUtils.normalizeLocation(it.path) !in excludedPathSet }
-            .filter { it.modificationTimeMillis <= cutoffTimeMillis }
             .sortedBy { it.path }
 
         if (candidateFolders.size > maxCandidateFolders) {
@@ -72,6 +64,53 @@ class UntrackedFolderCandidateDetector {
         }
 
         return candidateFolders
+    }
+
+    private fun skipReason(
+        storageFolder: StorageFolder,
+        normalizedActiveTableLocations: List<String>,
+        excludedPathSet: Set<String>,
+        cutoffTimeMillis: Long,
+    ): CandidateSkipReason? {
+        val normalizedFolder = StoragePathUtils.normalizeLocation(storageFolder.path)
+        val finalSegment = normalizedFolder.substringAfterLast('/')
+        val matchedSentinelPrefix =
+            SENTINEL_FOLDER_PREFIXES.firstOrNull { prefix ->
+                finalSegment.startsWith(prefix)
+            }
+
+        if (matchedSentinelPrefix != null) {
+            return CandidateSkipReason.SENTINEL_FOLDER
+        }
+
+        val claimedByActiveTable =
+            normalizedActiveTableLocations.any { activeLocation ->
+                StoragePathUtils.isSameOrChildLocation(
+                    candidateLocation = activeLocation,
+                    rootLocation = normalizedFolder,
+                )
+            }
+
+        if (claimedByActiveTable) {
+            return CandidateSkipReason.ACTIVE_OR_CONTAINS_ACTIVE_TABLE
+        }
+
+        if (normalizedFolder in excludedPathSet) {
+            return CandidateSkipReason.EXCLUDED_PATH
+        }
+
+        if (storageFolder.modificationTimeMillis > cutoffTimeMillis) {
+            return CandidateSkipReason.TOO_NEW
+        }
+
+        return null
+    }
+
+    private enum class CandidateSkipReason(val logValue: String) {
+        SENTINEL_FOLDER("sentinel_folder"),
+        ACTIVE_OR_CONTAINS_ACTIVE_TABLE("active_or_contains_active_table"),
+        EXCLUDED_PATH("excluded_path"),
+        TOO_NEW("too_new"),
     }
 
     private companion object {

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/candidate/UntrackedFolderCandidateDetector.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/candidate/UntrackedFolderCandidateDetector.kt
@@ -36,6 +36,8 @@ class UntrackedFolderCandidateDetector {
             .map { StoragePathUtils.normalizeLocation(it) }
             .toSet()
 
+        val skipReasonCounts = mutableMapOf<CandidateSkipReason, Int>()
+
         val candidateFolders = storageFolders
             .filter { storageFolder ->
                 val skipReason =
@@ -47,6 +49,7 @@ class UntrackedFolderCandidateDetector {
                     )
 
                 if (skipReason != null) {
+                    skipReasonCounts.merge(skipReason, 1, Int::plus)
                     logSkippedFolder(
                         storageFolder = storageFolder,
                         skipReason = skipReason,
@@ -57,6 +60,11 @@ class UntrackedFolderCandidateDetector {
                 skipReason == null
             }
             .sortedBy { it.path }
+
+        logSkipReasonSummary(
+            totalFolderCount = storageFolders.size,
+            skipReasonCounts = skipReasonCounts,
+        )
 
         if (candidateFolders.size > maxCandidateFolders) {
             throw TooManyCandidateFoldersException(
@@ -86,6 +94,11 @@ class UntrackedFolderCandidateDetector {
             return CandidateSkipReason.SENTINEL_FOLDER
         }
 
+        // Exact-match check is logically subsumed by the containment check below
+        // (isSameOrChildLocation returns true for equal paths), but we keep both so
+        // skip-reason logging distinguishes "candidate IS an active table" from
+        // "candidate CONTAINS an active table." Do not collapse without preserving
+        // both reasons explicitly.
         if (normalizedFolder in normalizedActiveTableLocations) {
             return CandidateSkipReason.ACTIVE_TABLE
         }
@@ -118,6 +131,10 @@ class UntrackedFolderCandidateDetector {
         skipReason: CandidateSkipReason,
         cutoffTimeMillis: Long,
     ) {
+        if (!logger.isDebugEnabled) {
+            return
+        }
+
         val message = when (skipReason) {
             CandidateSkipReason.TOO_NEW ->
                 "Storage folder was not selected as cleanup candidate: path=${storageFolder.path}, reason=${skipReason.logValue}, modifiedAt=${Instant.ofEpochMilli(storageFolder.modificationTimeMillis)}, cutoffTime=${Instant.ofEpochMilli(cutoffTimeMillis)}"
@@ -125,7 +142,26 @@ class UntrackedFolderCandidateDetector {
                 "Storage folder was not selected as cleanup candidate: path=${storageFolder.path}, reason=${skipReason.logValue}"
         }
 
-        logger.info(message)
+        logger.debug(message)
+    }
+
+    private fun logSkipReasonSummary(
+        totalFolderCount: Int,
+        skipReasonCounts: Map<CandidateSkipReason, Int>,
+    ) {
+        if (skipReasonCounts.isEmpty()) {
+            return
+        }
+
+        val totalSkipped = skipReasonCounts.values.sum()
+        val perReasonSummary =
+            CandidateSkipReason.entries.joinToString(", ") { reason ->
+                "${reason.logValue}=${skipReasonCounts[reason] ?: 0}"
+            }
+
+        logger.info(
+            "Skipped $totalSkipped of $totalFolderCount storage folder(s) during candidate detection: $perReasonSummary. Enable DEBUG logging on ${UntrackedFolderCandidateDetector::class.java.name} for per-folder skip reasons."
+        )
     }
 
     private enum class CandidateSkipReason(val logValue: String) {

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/candidate/UntrackedFolderCandidateDetector.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/candidate/UntrackedFolderCandidateDetector.kt
@@ -4,6 +4,7 @@ import com.iomete.cleanup.untrackedtablefolders.storage.StorageFolder
 import com.iomete.cleanup.untrackedtablefolders.storage.StoragePathUtils
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.time.Instant
 
 class TooManyCandidateFoldersException(
     val candidateCount: Int,
@@ -46,8 +47,10 @@ class UntrackedFolderCandidateDetector {
                     )
 
                 if (skipReason != null) {
-                    logger.info(
-                        "Storage folder was not selected as cleanup candidate: path=${storageFolder.path}, reason=${skipReason.logValue}"
+                    logSkippedFolder(
+                        storageFolder = storageFolder,
+                        skipReason = skipReason,
+                        cutoffTimeMillis = cutoffTimeMillis,
                     )
                 }
 
@@ -83,7 +86,11 @@ class UntrackedFolderCandidateDetector {
             return CandidateSkipReason.SENTINEL_FOLDER
         }
 
-        val claimedByActiveTable =
+        if (normalizedFolder in normalizedActiveTableLocations) {
+            return CandidateSkipReason.ACTIVE_TABLE
+        }
+
+        val containsActiveTable =
             normalizedActiveTableLocations.any { activeLocation ->
                 StoragePathUtils.isSameOrChildLocation(
                     candidateLocation = activeLocation,
@@ -91,8 +98,8 @@ class UntrackedFolderCandidateDetector {
                 )
             }
 
-        if (claimedByActiveTable) {
-            return CandidateSkipReason.ACTIVE_OR_CONTAINS_ACTIVE_TABLE
+        if (containsActiveTable) {
+            return CandidateSkipReason.CONTAINS_ACTIVE_TABLE
         }
 
         if (normalizedFolder in excludedPathSet) {
@@ -106,9 +113,25 @@ class UntrackedFolderCandidateDetector {
         return null
     }
 
+    private fun logSkippedFolder(
+        storageFolder: StorageFolder,
+        skipReason: CandidateSkipReason,
+        cutoffTimeMillis: Long,
+    ) {
+        val message = when (skipReason) {
+            CandidateSkipReason.TOO_NEW ->
+                "Storage folder was not selected as cleanup candidate: path=${storageFolder.path}, reason=${skipReason.logValue}, modifiedAt=${Instant.ofEpochMilli(storageFolder.modificationTimeMillis)}, cutoffTime=${Instant.ofEpochMilli(cutoffTimeMillis)}"
+            else ->
+                "Storage folder was not selected as cleanup candidate: path=${storageFolder.path}, reason=${skipReason.logValue}"
+        }
+
+        logger.info(message)
+    }
+
     private enum class CandidateSkipReason(val logValue: String) {
         SENTINEL_FOLDER("sentinel_folder"),
-        ACTIVE_OR_CONTAINS_ACTIVE_TABLE("active_or_contains_active_table"),
+        ACTIVE_TABLE("active_table"),
+        CONTAINS_ACTIVE_TABLE("contains_active_table"),
         EXCLUDED_PATH("excluded_path"),
         TOO_NEW("too_new"),
     }

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/logging/CleanupSummaryLogger.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/logging/CleanupSummaryLogger.kt
@@ -1,0 +1,107 @@
+package com.iomete.cleanup.untrackedtablefolders.logging
+
+import com.iomete.cleanup.untrackedtablefolders.storage.StorageSizeStats
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+
+@ApplicationScoped
+class CleanupSummaryLogger {
+
+    private val logger = Logger.getLogger(CleanupSummaryLogger::class.java)
+
+    fun logCleanupSummary(
+        catalog: String,
+        database: String,
+        discoveredDatabaseLocation: String?,
+        storageScanLocation: String,
+        activeTableLocations: List<String>,
+        storageFolderPaths: List<String>,
+        excludedPaths: List<String>,
+        candidateFolderPaths: List<String>,
+        candidateSizeStats: StorageSizeStats?,
+        deletedFolderPaths: List<String>,
+        deletedSizeStats: StorageSizeStats?,
+    ) {
+        val candidateFolderSet = candidateFolderPaths.toSet()
+        val protectedFolderPaths = activeTableLocations.toSet()
+        val nonCandidateStorageFolderPaths =
+            storageFolderPaths.filter { it !in candidateFolderSet }.sorted()
+
+        logBlankLines(3)
+        logger.info("========== Cleanup Untracked Table Folders Summary ==========")
+        logger.info("Catalog: $catalog")
+        logger.info("Configured database: $database")
+        logger.info("Discovered database location: $discoveredDatabaseLocation")
+        logger.info("Object storage scan root: $storageScanLocation")
+        logger.info("Protected catalog active table location count: ${activeTableLocations.size}")
+        logger.info("Immediate child storage folders scanned: ${storageFolderPaths.size}")
+        logger.info("Untracked candidate folder count: ${candidateFolderPaths.size}")
+        logger.info(
+            if (candidateSizeStats != null) {
+                "Estimated candidate size: ${formatBytes(candidateSizeStats.totalSizeBytes)} across ${candidateSizeStats.objectCount} object(s)"
+            } else {
+                "Estimated candidate size: skipped because collect_size_statistics=false"
+            }
+        )
+        logger.info("Deleted untracked folder count: ${deletedFolderPaths.size}")
+        logger.info(
+            if (deletedSizeStats != null) {
+                "Deleted size: ${formatBytes(deletedSizeStats.totalSizeBytes)} across ${deletedSizeStats.objectCount} object(s)"
+            } else {
+                "Deleted size: skipped because collect_size_statistics=false"
+            }
+        )
+        logger.info("Deletion performed: ${deletedFolderPaths.isNotEmpty()}")
+        logger.info("Protected catalog active table locations:")
+        logListOrNone(protectedFolderPaths.sorted())
+        logger.info("Effective excluded paths:")
+        logListOrNone(excludedPaths.sorted())
+        logger.info("Storage folders not selected as candidates:")
+        logListOrNone(nonCandidateStorageFolderPaths)
+        logger.info("Untracked candidate folders selected for cleanup:")
+        logListOrNone(candidateFolderPaths)
+        logger.info("Deleted folders:")
+        logListOrNone(deletedFolderPaths)
+        logger.info("============================================================")
+        logBlankLines(3)
+    }
+
+    private fun logBlankLines(count: Int) {
+        repeat(count) { logger.info("") }
+    }
+
+    private fun formatBytes(bytes: Long): String {
+        val units = listOf("B", "KB", "MB", "GB", "TB", "PB")
+        var value = bytes.toDouble()
+        var unitIndex = 0
+
+        while (value >= 1024 && unitIndex < units.lastIndex) {
+            value /= 1024
+            unitIndex += 1
+        }
+
+        return if (unitIndex == 0) {
+            "${value.toLong()} ${units[unitIndex]}"
+        } else {
+            String.format("%.2f %s", value, units[unitIndex])
+        }
+    }
+
+    private fun logListOrNone(values: List<String>) {
+        if (values.isEmpty()) {
+            logger.info("- none")
+        } else {
+            values.take(MAX_LOG_PATH_SAMPLE_SIZE).forEach { value ->
+                logger.info("- $value")
+            }
+
+            if (values.size > MAX_LOG_PATH_SAMPLE_SIZE) {
+                logger.info("- ... truncated ${values.size - MAX_LOG_PATH_SAMPLE_SIZE} additional path(s)")
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_LOG_PATH_SAMPLE_SIZE = 100
+    }
+}

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/logging/CleanupSummaryLogger.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/logging/CleanupSummaryLogger.kt
@@ -4,64 +4,66 @@ import com.iomete.cleanup.untrackedtablefolders.storage.StorageSizeStats
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
 
+data class CleanupSummary(
+    val catalog: String,
+    val database: String,
+    val discoveredDatabaseLocation: String?,
+    val storageScanLocation: String,
+    val activeTableLocations: List<String>,
+    val storageFolderPaths: List<String>,
+    val excludedPaths: List<String>,
+    val candidateFolderPaths: List<String>,
+    val candidateSizeStats: StorageSizeStats?,
+    val deletedFolderPaths: List<String>,
+    val deletedSizeStats: StorageSizeStats?,
+)
+
 @ApplicationScoped
 class CleanupSummaryLogger {
 
     private val logger = Logger.getLogger(CleanupSummaryLogger::class.java)
 
-    fun logCleanupSummary(
-        catalog: String,
-        database: String,
-        discoveredDatabaseLocation: String?,
-        storageScanLocation: String,
-        activeTableLocations: List<String>,
-        storageFolderPaths: List<String>,
-        excludedPaths: List<String>,
-        candidateFolderPaths: List<String>,
-        candidateSizeStats: StorageSizeStats?,
-        deletedFolderPaths: List<String>,
-        deletedSizeStats: StorageSizeStats?,
-    ) {
-        val candidateFolderSet = candidateFolderPaths.toSet()
-        val protectedFolderPaths = activeTableLocations.toSet()
+    fun logCleanupSummary(summary: CleanupSummary) {
+        val candidateFolderSet = summary.candidateFolderPaths.toSet()
+        val protectedFolderPaths = summary.activeTableLocations.toSet()
         val nonCandidateStorageFolderPaths =
-            storageFolderPaths.filter { it !in candidateFolderSet }.sorted()
+            summary.storageFolderPaths.filter { it !in candidateFolderSet }.sorted()
 
         logBlankLines(3)
         logger.info("========== Cleanup Untracked Table Folders Summary ==========")
-        logger.info("Catalog: $catalog")
-        logger.info("Configured database: $database")
-        logger.info("Discovered database location: $discoveredDatabaseLocation")
-        logger.info("Object storage scan root: $storageScanLocation")
-        logger.info("Protected catalog active table location count: ${activeTableLocations.size}")
-        logger.info("Immediate child storage folders scanned: ${storageFolderPaths.size}")
-        logger.info("Untracked candidate folder count: ${candidateFolderPaths.size}")
+        logger.info("Catalog: ${summary.catalog}")
+        logger.info("Configured database: ${summary.database}")
+        logger.info("Discovered database location: ${summary.discoveredDatabaseLocation}")
+        logger.info("Object storage scan root: ${summary.storageScanLocation}")
+        logger.info("Protected catalog active table location count: ${summary.activeTableLocations.size}")
+        logger.info("Immediate child storage folders scanned: ${summary.storageFolderPaths.size}")
+        logger.info("Untracked candidate folder count: ${summary.candidateFolderPaths.size}")
         logger.info(
-            if (candidateSizeStats != null) {
-                "Estimated candidate size: ${formatBytes(candidateSizeStats.totalSizeBytes)} across ${candidateSizeStats.objectCount} object(s)"
+            if (summary.candidateSizeStats != null) {
+                "Estimated candidate size: ${formatBytes(summary.candidateSizeStats.totalSizeBytes)} across ${summary.candidateSizeStats.objectCount} object(s)"
             } else {
                 "Estimated candidate size: skipped because collect_size_statistics=false"
             }
         )
-        logger.info("Deleted untracked folder count: ${deletedFolderPaths.size}")
+        logger.info("Deleted untracked folder count: ${summary.deletedFolderPaths.size}")
         logger.info(
-            if (deletedSizeStats != null) {
-                "Deleted size: ${formatBytes(deletedSizeStats.totalSizeBytes)} across ${deletedSizeStats.objectCount} object(s)"
+            if (summary.deletedSizeStats != null) {
+                "Deleted size: ${formatBytes(summary.deletedSizeStats.totalSizeBytes)} across ${summary.deletedSizeStats.objectCount} object(s)"
             } else {
                 "Deleted size: skipped because collect_size_statistics=false"
             }
         )
-        logger.info("Deletion performed: ${deletedFolderPaths.isNotEmpty()}")
+        logger.info("Deletion performed: ${summary.deletedFolderPaths.isNotEmpty()}")
         logger.info("Protected catalog active table locations:")
         logListOrNone(protectedFolderPaths.sorted())
         logger.info("Effective excluded paths:")
-        logListOrNone(excludedPaths.sorted())
+        logListOrNone(summary.excludedPaths.sorted())
         logger.info("Storage folders not selected as candidates:")
         logListOrNone(nonCandidateStorageFolderPaths)
         logger.info("Untracked candidate folders selected for cleanup:")
-        logListOrNone(candidateFolderPaths)
+        logListOrNone(summary.candidateFolderPaths)
         logger.info("Deleted folders:")
-        logListOrNone(deletedFolderPaths)
+        logListOrNone(summary.deletedFolderPaths)
         logger.info("============================================================")
         logBlankLines(3)
     }

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -208,12 +208,9 @@ class CleanupUntrackedTableFoldersService {
                         }
 
                     candidateFolders.forEach { folder ->
+                        val modifiedAt = Instant.ofEpochMilli(folder.modificationTimeMillis)
                         logger.info(
-                            "Candidate untracked table folder selected for cleanup: path=${folder.path}, modifiedAt=${
-                                Instant.ofEpochMilli(
-                                    folder.modificationTimeMillis
-                                )
-                            }"
+                            "Candidate untracked table folder selected for cleanup: path=${folder.path}, modifiedAt=$modifiedAt"
                         )
                     }
 
@@ -415,11 +412,19 @@ class CleanupUntrackedTableFoldersService {
     private fun effectiveExcludedPaths(
         database: String,
         storageScanLocation: String,
-    ): List<String> =
-        (normalizedConfiguredExcludePaths() + resolvedExcludeDatabaseFolderPaths(database, storageScanLocation))
+    ): List<String> {
+        val configuredExcludePaths = normalizedConfiguredExcludePaths()
+        val databaseFolderExcludePaths =
+            resolvedExcludeDatabaseFolderPaths(
+                database = database,
+                storageScanLocation = storageScanLocation,
+            )
+
+        return (configuredExcludePaths + databaseFolderExcludePaths)
             .map { StoragePathUtils.normalizeLocation(it) }
             .distinct()
             .sorted()
+    }
 
     private fun resolvedExcludeDatabaseFolderPaths(
         database: String,

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -1,6 +1,7 @@
 package com.iomete.cleanup.untrackedtablefolders.service
 
 import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditRecord
+import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditDiagnosticDetailsBuilder
 import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditTableService
 import com.iomete.cleanup.untrackedtablefolders.candidate.TooManyCandidateFoldersException
 import com.iomete.cleanup.untrackedtablefolders.candidate.UntrackedFolderCandidateDetector
@@ -31,6 +32,7 @@ class CleanupUntrackedTableFoldersService {
     @Inject lateinit var objectStorageDeletionService: ObjectStorageDeletionService
     @Inject lateinit var untrackedFolderCandidateDetector: UntrackedFolderCandidateDetector
     @Inject lateinit var cleanupAuditTableService: CleanupAuditTableService
+    @Inject lateinit var auditDiagnosticDetailsBuilder: CleanupAuditDiagnosticDetailsBuilder
     @Inject lateinit var cleanupSummaryLogger: CleanupSummaryLogger
     @Inject lateinit var storageScanLocationResolver: StorageScanLocationResolver
 
@@ -403,12 +405,6 @@ class CleanupUntrackedTableFoldersService {
             )
         }
 
-    private fun auditPathSample(paths: List<String>): String =
-        paths.take(MAX_AUDIT_PATH_SAMPLE_SIZE).joinToString("\n")
-
-    private fun isAuditPathSampleTruncated(paths: List<String>): Boolean =
-        paths.size > MAX_AUDIT_PATH_SAMPLE_SIZE
-
     private fun writeDatabaseLocationMissingAuditRecord(
         runId: String,
         databaseStartTime: Instant,
@@ -428,7 +424,7 @@ class CleanupUntrackedTableFoldersService {
             errorMessage = "Database location is missing; storage folder discovery was skipped.",
             discoveredDatabaseLocation = discoveredDatabaseLocation,
             activeTableCount = activeTableCount,
-            diagnosticDetails = diagnosticDetails(activeTableLocations = activeTableLocations),
+            diagnosticDetails = auditDiagnosticDetailsBuilder.build(activeTableLocations = activeTableLocations),
         )
     }
 
@@ -451,7 +447,7 @@ class CleanupUntrackedTableFoldersService {
                         "Cleanup was skipped to avoid wholesale deletion of immediate child folders.",
             discoveredDatabaseLocation = discoveredDatabaseLocation,
             activeTableCount = 0,
-            diagnosticDetails = diagnosticDetails(activeTableLocations = emptyList()),
+            diagnosticDetails = auditDiagnosticDetailsBuilder.build(activeTableLocations = emptyList()),
         )
     }
 
@@ -488,7 +484,7 @@ class CleanupUntrackedTableFoldersService {
             cutoffTime = cutoffTime,
             excludedPaths = excludedPaths,
             diagnosticDetails =
-                diagnosticDetails(
+                auditDiagnosticDetailsBuilder.build(
                     activeTableLocations = activeTableLocations,
                     storageFolderPaths = storageFolderPaths,
                     candidateFolderPaths = candidateFolderPaths,
@@ -513,6 +509,7 @@ class CleanupUntrackedTableFoldersService {
         cutoffTime: Instant,
         excludedPaths: List<String>,
     ) {
+        val candidateFolderPathSet = candidateFolderPaths.toSet()
         writeAuditRecord(
             runId = runId,
             databaseStartTime = databaseStartTime,
@@ -536,52 +533,14 @@ class CleanupUntrackedTableFoldersService {
             cutoffTime = cutoffTime,
             excludedPaths = excludedPaths,
             diagnosticDetails =
-                diagnosticDetails(
+                auditDiagnosticDetailsBuilder.build(
                     activeTableLocations = activeTableLocations,
                     storageFolderPaths = storageFolderPaths,
                     candidateFolderPaths = candidateFolderPaths,
-                    includeNonCandidateStorageFolders = true,
+                    nonCandidateStorageFolderPaths =
+                        storageFolderPaths.filter { it !in candidateFolderPathSet }.sorted(),
                 ),
         )
-    }
-
-    private fun diagnosticDetails(
-        activeTableLocations: List<String>,
-        storageFolderPaths: List<String> = emptyList(),
-        candidateFolderPaths: List<String> = emptyList(),
-        includeNonCandidateStorageFolders: Boolean = false,
-    ): Map<String, String> {
-        val details =
-            mutableMapOf(
-                "active_table_locations_sample" to auditPathSample(activeTableLocations),
-                "active_table_locations_truncated" to
-                        isAuditPathSampleTruncated(activeTableLocations).toString(),
-            )
-
-        if (storageFolderPaths.isNotEmpty()) {
-            details["storage_folder_paths_sample"] = auditPathSample(storageFolderPaths)
-            details["storage_folder_paths_truncated"] =
-                isAuditPathSampleTruncated(storageFolderPaths).toString()
-        }
-
-        if (candidateFolderPaths.isNotEmpty()) {
-            details["candidate_folder_paths_sample"] = auditPathSample(candidateFolderPaths)
-            details["candidate_folder_paths_truncated"] =
-                isAuditPathSampleTruncated(candidateFolderPaths).toString()
-        }
-
-        if (includeNonCandidateStorageFolders) {
-            val candidateFolderSet = candidateFolderPaths.toSet()
-            val nonCandidateStorageFolderPaths =
-                storageFolderPaths.filter { it !in candidateFolderSet }.sorted()
-
-            details["non_candidate_storage_folder_paths_sample"] =
-                auditPathSample(nonCandidateStorageFolderPaths)
-            details["non_candidate_storage_folder_paths_truncated"] =
-                isAuditPathSampleTruncated(nonCandidateStorageFolderPaths).toString()
-        }
-
-        return details
     }
 
     private fun writeAuditRecord(

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -797,11 +797,8 @@ class CleanupUntrackedTableFoldersService {
             val excludedDatabase = parts[0]
             val excludedFolder = parts[1]
 
-            if (excludedDatabase == database) {
-                StoragePathUtils.normalizeLocation("$storageScanLocation/$excludedFolder")
-            } else {
-                null
-            }
+            if (excludedDatabase != database) return@mapNotNull null
+            StoragePathUtils.normalizeLocation("$storageScanLocation/$excludedFolder")
         }
 
     private companion object {

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -7,6 +7,7 @@ import com.iomete.cleanup.untrackedtablefolders.candidate.UntrackedFolderCandida
 import com.iomete.cleanup.untrackedtablefolders.catalog.DatabaseNotFoundException
 import com.iomete.cleanup.untrackedtablefolders.catalog.CatalogDiscoveryService
 import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import com.iomete.cleanup.untrackedtablefolders.logging.CleanupSummaryLogger
 import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDeletionService
 import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDiscoveryService
 import com.iomete.cleanup.untrackedtablefolders.storage.StoragePathUtils
@@ -29,6 +30,7 @@ class CleanupUntrackedTableFoldersService {
     @Inject lateinit var objectStorageDeletionService: ObjectStorageDeletionService
     @Inject lateinit var untrackedFolderCandidateDetector: UntrackedFolderCandidateDetector
     @Inject lateinit var cleanupAuditTableService: CleanupAuditTableService
+    @Inject lateinit var cleanupSummaryLogger: CleanupSummaryLogger
     @Inject lateinit var storageScanLocationResolver: StorageScanLocationResolver
 
     fun run() {
@@ -276,7 +278,7 @@ class CleanupUntrackedTableFoldersService {
                         }
                     }
 
-                    logCleanupSummary(
+                    cleanupSummaryLogger.logCleanupSummary(
                         catalog = discoveredDatabase.catalog,
                         database = discoveredDatabase.database,
                         discoveredDatabaseLocation = discoveredDatabase.location,
@@ -397,97 +399,6 @@ class CleanupUntrackedTableFoldersService {
                 totalSizeBytes = total.totalSizeBytes + current.totalSizeBytes,
             )
         }
-
-    private fun logBlankLines(count: Int) {
-        repeat(count) { logger.info("") }
-    }
-
-    private fun logCleanupSummary(
-        catalog: String,
-        database: String,
-        discoveredDatabaseLocation: String?,
-        storageScanLocation: String,
-        activeTableLocations: List<String>,
-        storageFolderPaths: List<String>,
-        excludedPaths: List<String>,
-        candidateFolderPaths: List<String>,
-        candidateSizeStats: StorageSizeStats?,
-        deletedFolderPaths: List<String>,
-        deletedSizeStats: StorageSizeStats?,
-    ) {
-        val candidateFolderSet = candidateFolderPaths.toSet()
-        val protectedFolderPaths = activeTableLocations.toSet()
-        val nonCandidateStorageFolderPaths =
-            storageFolderPaths.filter { it !in candidateFolderSet }.sorted()
-        logBlankLines(3)
-        logger.info("========== Cleanup Untracked Table Folders Summary ==========")
-        logger.info("Catalog: $catalog")
-        logger.info("Configured database: $database")
-        logger.info("Discovered database location: $discoveredDatabaseLocation")
-        logger.info("Object storage scan root: $storageScanLocation")
-        logger.info("Protected catalog active table location count: ${activeTableLocations.size}")
-        logger.info("Immediate child storage folders scanned: ${storageFolderPaths.size}")
-        logger.info("Untracked candidate folder count: ${candidateFolderPaths.size}")
-        logger.info(
-            if (candidateSizeStats != null) {
-                "Estimated candidate size: ${formatBytes(candidateSizeStats.totalSizeBytes)} across ${candidateSizeStats.objectCount} object(s)"
-            } else {
-                "Estimated candidate size: skipped because collect_size_statistics=false"
-            }
-        )
-        logger.info("Deleted untracked folder count: ${deletedFolderPaths.size}")
-        logger.info(
-            if (deletedSizeStats != null) {
-                "Deleted size: ${formatBytes(deletedSizeStats.totalSizeBytes)} across ${deletedSizeStats.objectCount} object(s)"
-            } else {
-                "Deleted size: skipped because collect_size_statistics=false"
-            }
-        )
-        logger.info("Deletion performed: ${deletedFolderPaths.isNotEmpty()}")
-        logger.info("Protected catalog active table locations:")
-        logListOrNone(protectedFolderPaths.sorted())
-        logger.info("Effective excluded paths:")
-        logListOrNone(excludedPaths.sorted())
-        logger.info("Storage folders not selected as candidates:")
-        logListOrNone(nonCandidateStorageFolderPaths)
-        logger.info("Untracked candidate folders selected for cleanup:")
-        logListOrNone(candidateFolderPaths)
-        logger.info("Deleted folders:")
-        logListOrNone(deletedFolderPaths)
-        logger.info("============================================================")
-        logBlankLines(3)
-    }
-
-    private fun formatBytes(bytes: Long): String {
-        val units = listOf("B", "KB", "MB", "GB", "TB", "PB")
-        var value = bytes.toDouble()
-        var unitIndex = 0
-
-        while (value >= 1024 && unitIndex < units.lastIndex) {
-            value /= 1024
-            unitIndex += 1
-        }
-
-        return if (unitIndex == 0) {
-            "$bytes ${units[unitIndex]}"
-        } else {
-            "%.2f %s".format(value, units[unitIndex])
-        }
-    }
-
-    private fun logListOrNone(values: List<String>) {
-        if (values.isEmpty()) {
-            logger.info("- none")
-        } else {
-            values.take(MAX_AUDIT_PATH_SAMPLE_SIZE).forEach { value ->
-                logger.info("- $value")
-            }
-
-            if (values.size > MAX_AUDIT_PATH_SAMPLE_SIZE) {
-                logger.info("- ... truncated ${values.size - MAX_AUDIT_PATH_SAMPLE_SIZE} additional path(s)")
-            }
-        }
-    }
 
     private fun auditPathSample(paths: List<String>): String =
         paths.take(MAX_AUDIT_PATH_SAMPLE_SIZE).joinToString("\n")

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -10,6 +10,7 @@ import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
 import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDeletionService
 import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDiscoveryService
 import com.iomete.cleanup.untrackedtablefolders.storage.StoragePathUtils
+import com.iomete.cleanup.untrackedtablefolders.storage.StorageScanLocationResolver
 import com.iomete.cleanup.untrackedtablefolders.storage.StorageSizeStats
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -28,6 +29,7 @@ class CleanupUntrackedTableFoldersService {
     @Inject lateinit var objectStorageDeletionService: ObjectStorageDeletionService
     @Inject lateinit var untrackedFolderCandidateDetector: UntrackedFolderCandidateDetector
     @Inject lateinit var cleanupAuditTableService: CleanupAuditTableService
+    @Inject lateinit var storageScanLocationResolver: StorageScanLocationResolver
 
     fun run() {
 
@@ -95,7 +97,7 @@ class CleanupUntrackedTableFoldersService {
                     )
                 } else {
                     val storageScanLocation =
-                        resolveStorageScanLocation(
+                        storageScanLocationResolver.resolve(
                             databaseLocation = discoveredDatabase.location,
                             activeTableLocations =
                                 discoveredDatabase.tables.mapNotNull { it.location },
@@ -801,62 +803,6 @@ class CleanupUntrackedTableFoldersService {
                 null
             }
         }
-
-    private fun resolveStorageScanLocation(
-        databaseLocation: String,
-        activeTableLocations: List<String>,
-    ): String {
-        val inferredScanLocations =
-            activeTableLocations.mapNotNull { parentLocation(it) }.distinct().sorted()
-
-        val resolvedScanLocation =
-            when (inferredScanLocations.size) {
-                0 -> {
-                    logger.warn(
-                        "No active table locations were discovered for databaseLocation=$databaseLocation. Falling back to discovered database location for storage scan. This may miss untracked folders if the database location differs from the actual table storage root."
-                    )
-                    databaseLocation
-                }
-                1 -> inferredScanLocations.single()
-                else -> {
-                    logger.warn(
-                        "Multiple active table parent locations were discovered for databaseLocation=$databaseLocation: $inferredScanLocations. Falling back to database location."
-                    )
-                    databaseLocation
-                }
-            }
-
-        validateStorageScanLocation(
-            databaseLocation = databaseLocation,
-            storageScanLocation = resolvedScanLocation,
-        )
-
-        return resolvedScanLocation
-    }
-
-    private fun validateStorageScanLocation(
-        databaseLocation: String,
-        storageScanLocation: String,
-    ) {
-        val allowedRoots = StoragePathUtils.allowedDatabaseRoots(databaseLocation)
-
-        if (!StoragePathUtils.isInsideAnyRoot(storageScanLocation, allowedRoots)) {
-            throw IllegalStateException(
-                "Resolved storage scan location escapes database boundary. databaseLocation=$databaseLocation, storageScanLocation=$storageScanLocation, allowedRoots=$allowedRoots"
-            )
-        }
-    }
-
-    private fun parentLocation(location: String): String? {
-        val normalizedLocation = location.trim().trimEnd('/')
-        val lastSlashIndex = normalizedLocation.lastIndexOf('/')
-
-        return if (lastSlashIndex <= 0) {
-            null
-        } else {
-            normalizedLocation.substring(0, lastSlashIndex)
-        }
-    }
 
     private companion object {
 

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -9,9 +9,10 @@ import com.iomete.cleanup.untrackedtablefolders.catalog.CatalogDiscoveryService
 import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
 import com.iomete.cleanup.untrackedtablefolders.logging.CleanupSummary
 import com.iomete.cleanup.untrackedtablefolders.logging.CleanupSummaryLogger
-import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDeletionService
+import com.iomete.cleanup.untrackedtablefolders.storage.CandidateDeletionGate
+import com.iomete.cleanup.untrackedtablefolders.storage.CandidateSizeStatCollector
+import com.iomete.cleanup.untrackedtablefolders.storage.ExcludePathResolver
 import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDiscoveryService
-import com.iomete.cleanup.untrackedtablefolders.storage.StoragePathUtils
 import com.iomete.cleanup.untrackedtablefolders.storage.StorageScanLocationResolver
 import com.iomete.cleanup.untrackedtablefolders.storage.StorageSizeStats
 import jakarta.enterprise.context.ApplicationScoped
@@ -28,12 +29,14 @@ class CleanupUntrackedTableFoldersService {
     @Inject lateinit var config: ApplicationConfig
     @Inject lateinit var catalogDiscoveryService: CatalogDiscoveryService
     @Inject lateinit var objectStorageDiscoveryService: ObjectStorageDiscoveryService
-    @Inject lateinit var objectStorageDeletionService: ObjectStorageDeletionService
     @Inject lateinit var untrackedFolderCandidateDetector: UntrackedFolderCandidateDetector
     @Inject lateinit var cleanupAuditTableService: CleanupAuditTableService
     @Inject lateinit var cleanupAuditRecorder: CleanupAuditRecorder
     @Inject lateinit var cleanupSummaryLogger: CleanupSummaryLogger
     @Inject lateinit var storageScanLocationResolver: StorageScanLocationResolver
+    @Inject lateinit var excludePathResolver: ExcludePathResolver
+    @Inject lateinit var candidateSizeStatCollector: CandidateSizeStatCollector
+    @Inject lateinit var candidateDeletionGate: CandidateDeletionGate
 
     fun run() {
 
@@ -45,7 +48,7 @@ class CleanupUntrackedTableFoldersService {
 
         config.databases.forEach { database ->
             val databaseStartTime = Instant.now()
-            var effectiveExcludedPathsForAudit = normalizedConfiguredExcludePaths()
+            var effectiveExcludedPathsForAudit = excludePathResolver.normalizedConfiguredExcludePaths()
             try {
                 val discoveredDatabase =
                     catalogDiscoveryService.discoverDatabase(
@@ -77,7 +80,7 @@ class CleanupUntrackedTableFoldersService {
                         catalogName = discoveredDatabase.catalog,
                         databaseName = discoveredDatabase.database,
                         discoveredDatabaseLocation = discoveredDatabase.location,
-                        excludedPaths = normalizedConfiguredExcludePaths(),
+                        excludedPaths = excludePathResolver.normalizedConfiguredExcludePaths(),
                     )
 
                     return@forEach
@@ -95,7 +98,7 @@ class CleanupUntrackedTableFoldersService {
                         databaseName = discoveredDatabase.database,
                         discoveredDatabaseLocation = discoveredDatabase.location,
                         errorMessage = "Database location is missing; storage folder discovery was skipped.",
-                        excludedPaths = normalizedConfiguredExcludePaths(),
+                        excludedPaths = excludePathResolver.normalizedConfiguredExcludePaths(),
                         activeTableCount = discoveredDatabase.tables.size.toLong(),
                         activeTableLocations =
                             discoveredDatabase.tables
@@ -138,7 +141,7 @@ class CleanupUntrackedTableFoldersService {
                         discoveredDatabase.tables.mapNotNull { it.location }.sorted()
 
                     val effectiveExcludedPaths =
-                        effectiveExcludedPaths(
+                        excludePathResolver.effectiveExcludedPaths(
                             database = discoveredDatabase.database,
                             storageScanLocation = storageScanLocation,
                         )
@@ -199,10 +202,10 @@ class CleanupUntrackedTableFoldersService {
 
                     val candidateFolderPaths = candidateFolders.map { it.path }.sorted()
                     val candidateSizeStatsByFolder =
-                        collectCandidateSizeStatsByFolder(candidateFolderPaths)
+                        candidateSizeStatCollector.collectPerFolder(candidateFolderPaths)
                     val candidateSizeStats: StorageSizeStats? =
                         if (config.collectSizeStatistics) {
-                            sumSizeStats(candidateSizeStatsByFolder.values)
+                            candidateSizeStatCollector.sum(candidateSizeStatsByFolder.values)
                         } else {
                             null
                         }
@@ -215,57 +218,17 @@ class CleanupUntrackedTableFoldersService {
                     }
 
                     val deletedFolders =
-                        when {
-                            config.dryRun -> emptyList()
-
-                            !config.deleteEnabled ->
-                                throw IllegalStateException(
-                                    "delete_enabled must be true before deleting candidate folders"
-                                )
-
-                            else -> {
-                                val currentActiveTableLocations =
-                                    catalogDiscoveryService
-                                        .discoverDatabase(
-                                            catalog = discoveredDatabase.catalog,
-                                            database = discoveredDatabase.database,
-                                        )
-                                        .tables
-                                        .mapNotNull { it.location }
-                                        .map { StoragePathUtils.normalizeLocation(it) }
-
-                                candidateFolders
-                                    .mapNotNull { candidateFolder ->
-                                        val normalizedCandidatePath =
-                                            StoragePathUtils.normalizeLocation(candidateFolder.path)
-
-                                        val claimedByActiveTable =
-                                            currentActiveTableLocations.any { activeLocation ->
-                                                StoragePathUtils.isSameOrChildLocation(
-                                                    candidateLocation = activeLocation,
-                                                    rootLocation = normalizedCandidatePath,
-                                                )
-                                            }
-
-                                        if (claimedByActiveTable) {
-                                            logger.warn(
-                                                "Skipping deletion because candidate folder is or contains an active table location: path=${candidateFolder.path}"
-                                            )
-                                            null
-                                        } else {
-                                            objectStorageDeletionService
-                                                .deleteFolderRecursively(candidateFolder.path)
-                                                .takeIf { it.deleted }
-                                                ?.path
-                                        }
-                                    }
-                                    .sorted()
-                            }
-                        }
+                        candidateDeletionGate.deleteCandidates(
+                            catalog = discoveredDatabase.catalog,
+                            database = discoveredDatabase.database,
+                            candidateFolders = candidateFolders,
+                        )
 
                     val deletedSizeStats: StorageSizeStats? =
                         if (config.collectSizeStatistics) {
-                            sumSizeStats(deletedFolders.mapNotNull { candidateSizeStatsByFolder[it] })
+                            candidateSizeStatCollector.sum(
+                                deletedFolders.mapNotNull { candidateSizeStatsByFolder[it] }
+                            )
                         } else {
                             null
                         }
@@ -352,92 +315,4 @@ class CleanupUntrackedTableFoldersService {
         }
     }
 
-    private fun collectCandidateSizeStatsByFolder(
-        candidateFolderPaths: List<String>,
-    ): Map<String, StorageSizeStats> {
-        if (candidateFolderPaths.isEmpty()) {
-            return emptyMap()
-        }
-
-        if (!config.collectSizeStatistics) {
-            logger.info(
-                "Skipping size statistics because collect_size_statistics=false. Candidate and deleted size audit fields will be NULL."
-            )
-            return emptyMap()
-        }
-
-        logger.info(
-            "Collecting size statistics for ${candidateFolderPaths.size} candidate folder(s). This may take time for folders with many objects. To skip this step, set collect_size_statistics=false."
-        )
-
-        val result = mutableMapOf<String, StorageSizeStats>()
-        var failedFolderCount = 0
-
-        candidateFolderPaths.forEach { candidateFolderPath ->
-            try {
-                result[candidateFolderPath] =
-                    objectStorageDiscoveryService.collectSizeStats(listOf(candidateFolderPath))
-            } catch (th: Throwable) {
-                failedFolderCount += 1
-                logger.warn(
-                    "Failed to collect size statistics for candidate folder; recording unknown size and continuing without aborting cleanup: path=$candidateFolderPath",
-                    th,
-                )
-            }
-        }
-
-        if (failedFolderCount > 0) {
-            logger.warn(
-                "Size statistics collection failed for $failedFolderCount of ${candidateFolderPaths.size} candidate folder(s). Candidate and deleted size audit fields exclude the failed folders."
-            )
-        }
-
-        return result
-    }
-
-    private fun sumSizeStats(stats: Iterable<StorageSizeStats>): StorageSizeStats =
-        stats.fold(StorageSizeStats.ZERO) { total, current ->
-            StorageSizeStats(
-                objectCount = total.objectCount + current.objectCount,
-                totalSizeBytes = total.totalSizeBytes + current.totalSizeBytes,
-            )
-        }
-
-    private fun normalizedConfiguredExcludePaths(): List<String> =
-        config.excludePaths
-            .map { StoragePathUtils.normalizeLocation(it) }
-            .distinct()
-            .sorted()
-
-    private fun effectiveExcludedPaths(
-        database: String,
-        storageScanLocation: String,
-    ): List<String> {
-        val configuredExcludePaths = normalizedConfiguredExcludePaths()
-        val databaseFolderExcludePaths =
-            resolvedExcludeDatabaseFolderPaths(
-                database = database,
-                storageScanLocation = storageScanLocation,
-            )
-
-        return (configuredExcludePaths + databaseFolderExcludePaths)
-            .map { StoragePathUtils.normalizeLocation(it) }
-            .distinct()
-            .sorted()
-    }
-
-    private fun resolvedExcludeDatabaseFolderPaths(
-        database: String,
-        storageScanLocation: String,
-    ): List<String> =
-        config.excludeDatabaseFolders.mapNotNull { excludedDatabaseFolder ->
-            val parts = excludedDatabaseFolder.split(".", limit = 2)
-            if (parts.size != 2) return@mapNotNull null
-
-            val excludedDatabase = parts[0]
-            val excludedFolder = parts[1]
-
-            if (excludedDatabase != database) return@mapNotNull null
-            StoragePathUtils.normalizeLocation("$storageScanLocation/$excludedFolder")
-        }
 }

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -7,6 +7,7 @@ import com.iomete.cleanup.untrackedtablefolders.candidate.UntrackedFolderCandida
 import com.iomete.cleanup.untrackedtablefolders.catalog.DatabaseNotFoundException
 import com.iomete.cleanup.untrackedtablefolders.catalog.CatalogDiscoveryService
 import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import com.iomete.cleanup.untrackedtablefolders.logging.CleanupSummary
 import com.iomete.cleanup.untrackedtablefolders.logging.CleanupSummaryLogger
 import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDeletionService
 import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDiscoveryService
@@ -279,17 +280,19 @@ class CleanupUntrackedTableFoldersService {
                     }
 
                     cleanupSummaryLogger.logCleanupSummary(
-                        catalog = discoveredDatabase.catalog,
-                        database = discoveredDatabase.database,
-                        discoveredDatabaseLocation = discoveredDatabase.location,
-                        storageScanLocation = storageScanLocation,
-                        activeTableLocations = activeTableLocations,
-                        storageFolderPaths = storageFolderPaths,
-                        excludedPaths = effectiveExcludedPaths,
-                        candidateFolderPaths = candidateFolderPaths,
-                        candidateSizeStats = candidateSizeStats,
-                        deletedFolderPaths = deletedFolders,
-                        deletedSizeStats = deletedSizeStats,
+                        CleanupSummary(
+                            catalog = discoveredDatabase.catalog,
+                            database = discoveredDatabase.database,
+                            discoveredDatabaseLocation = discoveredDatabase.location,
+                            storageScanLocation = storageScanLocation,
+                            activeTableLocations = activeTableLocations,
+                            storageFolderPaths = storageFolderPaths,
+                            excludedPaths = effectiveExcludedPaths,
+                            candidateFolderPaths = candidateFolderPaths,
+                            candidateSizeStats = candidateSizeStats,
+                            deletedFolderPaths = deletedFolders,
+                            deletedSizeStats = deletedSizeStats,
+                        )
                     )
 
                     writeSuccessAuditRecord(

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersService.kt
@@ -1,7 +1,6 @@
 package com.iomete.cleanup.untrackedtablefolders.service
 
-import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditRecord
-import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditDiagnosticDetailsBuilder
+import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditRecorder
 import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditTableService
 import com.iomete.cleanup.untrackedtablefolders.candidate.TooManyCandidateFoldersException
 import com.iomete.cleanup.untrackedtablefolders.candidate.UntrackedFolderCandidateDetector
@@ -32,7 +31,7 @@ class CleanupUntrackedTableFoldersService {
     @Inject lateinit var objectStorageDeletionService: ObjectStorageDeletionService
     @Inject lateinit var untrackedFolderCandidateDetector: UntrackedFolderCandidateDetector
     @Inject lateinit var cleanupAuditTableService: CleanupAuditTableService
-    @Inject lateinit var auditDiagnosticDetailsBuilder: CleanupAuditDiagnosticDetailsBuilder
+    @Inject lateinit var cleanupAuditRecorder: CleanupAuditRecorder
     @Inject lateinit var cleanupSummaryLogger: CleanupSummaryLogger
     @Inject lateinit var storageScanLocationResolver: StorageScanLocationResolver
 
@@ -72,12 +71,13 @@ class CleanupUntrackedTableFoldersService {
                                 "catalog=${discoveredDatabase.catalog}, database=${discoveredDatabase.database}, totalCatalogTables=${discoveredDatabase.tables.size}"
                     )
 
-                    writeNoActiveTablesAuditRecord(
+                    cleanupAuditRecorder.recordNoActiveTables(
                         runId = runId,
                         databaseStartTime = databaseStartTime,
                         catalogName = discoveredDatabase.catalog,
                         databaseName = discoveredDatabase.database,
                         discoveredDatabaseLocation = discoveredDatabase.location,
+                        excludedPaths = normalizedConfiguredExcludePaths(),
                     )
 
                     return@forEach
@@ -88,12 +88,14 @@ class CleanupUntrackedTableFoldersService {
                         "Skipping storage folder discovery because database location is missing for catalog=${discoveredDatabase.catalog}, database=${discoveredDatabase.database}"
                     )
 
-                    writeDatabaseLocationMissingAuditRecord(
+                    cleanupAuditRecorder.recordDatabaseLocationMissing(
                         runId = runId,
                         databaseStartTime = databaseStartTime,
                         catalogName = discoveredDatabase.catalog,
                         databaseName = discoveredDatabase.database,
                         discoveredDatabaseLocation = discoveredDatabase.location,
+                        errorMessage = "Database location is missing; storage folder discovery was skipped.",
+                        excludedPaths = normalizedConfiguredExcludePaths(),
                         activeTableCount = discoveredDatabase.tables.size.toLong(),
                         activeTableLocations =
                             discoveredDatabase.tables
@@ -172,7 +174,7 @@ class CleanupUntrackedTableFoldersService {
                             )
                             val candidateFolderPaths = th.candidateFolderPaths.sorted()
 
-                            writeTooManyCandidateFoldersAuditRecord(
+                            cleanupAuditRecorder.recordTooManyCandidateFolders(
                                 runId = runId,
                                 databaseStartTime = databaseStartTime,
                                 catalogName = discoveredDatabase.catalog,
@@ -183,10 +185,9 @@ class CleanupUntrackedTableFoldersService {
                                 activeTableLocations = activeTableLocations,
                                 storageFolderPaths = storageFolderPaths,
                                 candidateFolderPaths = candidateFolderPaths,
-                                candidateCount = th.candidateCount.toLong(),
                                 cutoffTime = cutoffTime,
                                 excludedPaths = effectiveExcludedPaths,
-                                errorMessage = th.message,
+                                errorMessage = th.message ?: th::class.java.name,
                             )
 
                             return@forEach
@@ -297,7 +298,7 @@ class CleanupUntrackedTableFoldersService {
                         )
                     )
 
-                    writeSuccessAuditRecord(
+                    cleanupAuditRecorder.recordSuccess(
                         runId = runId,
                         databaseStartTime = databaseStartTime,
                         catalogName = discoveredDatabase.catalog,
@@ -324,7 +325,7 @@ class CleanupUntrackedTableFoldersService {
                     th,
                 )
 
-                writeDatabaseNotFoundAuditRecord(
+                cleanupAuditRecorder.recordDatabaseNotFound(
                     runId = runId,
                     database = database,
                     databaseStartTime = databaseStartTime,
@@ -333,7 +334,7 @@ class CleanupUntrackedTableFoldersService {
             } catch (th: Throwable) {
                 logger.error("Cleanup failed for catalog=${config.catalog}, database=$database", th)
 
-                writeFailedAuditRecord(
+                cleanupAuditRecorder.recordFailed(
                     runId = runId,
                     database = database,
                     databaseStartTime = databaseStartTime,
@@ -405,245 +406,6 @@ class CleanupUntrackedTableFoldersService {
             )
         }
 
-    private fun writeDatabaseLocationMissingAuditRecord(
-        runId: String,
-        databaseStartTime: Instant,
-        catalogName: String,
-        databaseName: String,
-        discoveredDatabaseLocation: String?,
-        activeTableCount: Long,
-        activeTableLocations: List<String>,
-    ) {
-        writeAuditRecord(
-            runId = runId,
-            databaseStartTime = databaseStartTime,
-            catalogName = catalogName,
-            databaseName = databaseName,
-            status = STATUS_SKIPPED,
-            statusReason = "database_location_missing",
-            errorMessage = "Database location is missing; storage folder discovery was skipped.",
-            discoveredDatabaseLocation = discoveredDatabaseLocation,
-            activeTableCount = activeTableCount,
-            diagnosticDetails = auditDiagnosticDetailsBuilder.build(activeTableLocations = activeTableLocations),
-        )
-    }
-
-    private fun writeNoActiveTablesAuditRecord(
-        runId: String,
-        databaseStartTime: Instant,
-        catalogName: String,
-        databaseName: String,
-        discoveredDatabaseLocation: String?,
-    ) {
-        writeAuditRecord(
-            runId = runId,
-            databaseStartTime = databaseStartTime,
-            catalogName = catalogName,
-            databaseName = databaseName,
-            status = STATUS_SKIPPED,
-            statusReason = "no_active_tables_in_database",
-            errorMessage =
-                "Database has no active tables with discoverable locations in the catalog. " +
-                        "Cleanup was skipped to avoid wholesale deletion of immediate child folders.",
-            discoveredDatabaseLocation = discoveredDatabaseLocation,
-            activeTableCount = 0,
-            diagnosticDetails = auditDiagnosticDetailsBuilder.build(activeTableLocations = emptyList()),
-        )
-    }
-
-    private fun writeTooManyCandidateFoldersAuditRecord(
-        runId: String,
-        databaseStartTime: Instant,
-        catalogName: String,
-        databaseName: String,
-        discoveredDatabaseLocation: String?,
-        storageScanLocation: String,
-        activeTableCount: Long,
-        activeTableLocations: List<String>,
-        storageFolderPaths: List<String>,
-        candidateFolderPaths: List<String>,
-        candidateCount: Long,
-        cutoffTime: Instant,
-        excludedPaths: List<String>,
-        errorMessage: String?,
-    ) {
-        writeAuditRecord(
-            runId = runId,
-            databaseStartTime = databaseStartTime,
-            catalogName = catalogName,
-            databaseName = databaseName,
-            status = STATUS_SKIPPED,
-            statusReason = "too_many_candidate_folders",
-            errorMessage = errorMessage,
-            discoveredDatabaseLocation = discoveredDatabaseLocation,
-            storageScanLocation = storageScanLocation,
-            activeTableCount = activeTableCount,
-            storageFolderCount = storageFolderPaths.size.toLong(),
-            candidateFolderCount = candidateCount,
-            candidateFolders = candidateFolderPaths.take(MAX_AUDIT_PATH_SAMPLE_SIZE),
-            cutoffTime = cutoffTime,
-            excludedPaths = excludedPaths,
-            diagnosticDetails =
-                auditDiagnosticDetailsBuilder.build(
-                    activeTableLocations = activeTableLocations,
-                    storageFolderPaths = storageFolderPaths,
-                    candidateFolderPaths = candidateFolderPaths,
-                ),
-        )
-    }
-
-    private fun writeSuccessAuditRecord(
-        runId: String,
-        databaseStartTime: Instant,
-        catalogName: String,
-        databaseName: String,
-        discoveredDatabaseLocation: String?,
-        storageScanLocation: String,
-        activeTableCount: Long,
-        activeTableLocations: List<String>,
-        storageFolderPaths: List<String>,
-        candidateFolderPaths: List<String>,
-        candidateSizeStats: StorageSizeStats?,
-        deletedFolderPaths: List<String>,
-        deletedSizeStats: StorageSizeStats?,
-        cutoffTime: Instant,
-        excludedPaths: List<String>,
-    ) {
-        val candidateFolderPathSet = candidateFolderPaths.toSet()
-        writeAuditRecord(
-            runId = runId,
-            databaseStartTime = databaseStartTime,
-            catalogName = catalogName,
-            databaseName = databaseName,
-            status = STATUS_SUCCESS,
-            statusReason = null,
-            errorMessage = null,
-            discoveredDatabaseLocation = discoveredDatabaseLocation,
-            storageScanLocation = storageScanLocation,
-            activeTableCount = activeTableCount,
-            storageFolderCount = storageFolderPaths.size.toLong(),
-            candidateFolderCount = candidateFolderPaths.size.toLong(),
-            candidateObjectCount = candidateSizeStats?.objectCount,
-            candidateTotalSizeBytes = candidateSizeStats?.totalSizeBytes,
-            deletedFolderCount = deletedFolderPaths.size.toLong(),
-            deletedObjectCount = deletedSizeStats?.objectCount,
-            deletedTotalSizeBytes = deletedSizeStats?.totalSizeBytes,
-            candidateFolders = candidateFolderPaths,
-            deletedFolders = deletedFolderPaths,
-            cutoffTime = cutoffTime,
-            excludedPaths = excludedPaths,
-            diagnosticDetails =
-                auditDiagnosticDetailsBuilder.build(
-                    activeTableLocations = activeTableLocations,
-                    storageFolderPaths = storageFolderPaths,
-                    candidateFolderPaths = candidateFolderPaths,
-                    nonCandidateStorageFolderPaths =
-                        storageFolderPaths.filter { it !in candidateFolderPathSet }.sorted(),
-                ),
-        )
-    }
-
-    private fun writeAuditRecord(
-        runId: String,
-        databaseStartTime: Instant,
-        catalogName: String,
-        databaseName: String,
-        status: String,
-        statusReason: String?,
-        errorMessage: String?,
-        discoveredDatabaseLocation: String? = null,
-        storageScanLocation: String = "",
-        activeTableCount: Long = 0,
-        storageFolderCount: Long = 0,
-        candidateFolderCount: Long = 0,
-        candidateObjectCount: Long? = null,
-        candidateTotalSizeBytes: Long? = null,
-        deletedFolderCount: Long = 0,
-        deletedObjectCount: Long? = null,
-        deletedTotalSizeBytes: Long? = null,
-        candidateFolders: List<String> = emptyList(),
-        deletedFolders: List<String> = emptyList(),
-        cutoffTime: Instant? = null,
-        excludedPaths: List<String> = normalizedConfiguredExcludePaths(),
-        diagnosticDetails: Map<String, String> = emptyMap(),
-    ) {
-        cleanupAuditTableService.writeAuditRecord(
-            CleanupAuditRecord(
-                runId = runId,
-                sparkAppId = cleanupAuditTableService.currentSparkAppId(),
-                runtimeComputeId = cleanupAuditTableService.currentRuntimeComputeId(),
-                runtimeComputeNamespace = cleanupAuditTableService.currentRuntimeComputeNamespace(),
-                runtimeDomain = cleanupAuditTableService.currentRuntimeDomain(),
-                runtimeUser = cleanupAuditTableService.currentRuntimeUser(),
-                externalJobId = cleanupAuditTableService.currentExternalJobId(),
-                platformStartedBy = cleanupAuditTableService.currentPlatformStartedBy(),
-                catalogName = catalogName,
-                databaseName = databaseName,
-                operation = OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS,
-                dryRun = config.dryRun,
-                deleteEnabled = config.deleteEnabled,
-                olderThanHours = config.olderThanHours,
-                cutoffTime = cutoffTime,
-                maxCandidateFoldersPerDatabase = config.maxCandidateFoldersPerDatabase,
-                excludedPaths = excludedPaths.sorted(),
-                status = status,
-                statusReason = statusReason,
-                errorMessage = errorMessage,
-                discoveredDatabaseLocation = discoveredDatabaseLocation,
-                storageScanLocation = storageScanLocation,
-                activeTableCount = activeTableCount,
-                storageFolderCount = storageFolderCount,
-                candidateFolderCount = candidateFolderCount,
-                candidateObjectCount = candidateObjectCount,
-                candidateTotalSizeBytes = candidateTotalSizeBytes,
-                deletedFolderCount = deletedFolderCount,
-                deletedObjectCount = deletedObjectCount,
-                deletedTotalSizeBytes = deletedTotalSizeBytes,
-                candidateFolders = candidateFolders,
-                deletedFolders = deletedFolders,
-                diagnosticDetails = diagnosticDetails,
-                startTime = databaseStartTime,
-                endTime = Instant.now(),
-            )
-        )
-    }
-
-    private fun writeDatabaseNotFoundAuditRecord(
-        runId: String,
-        database: String,
-        databaseStartTime: Instant,
-        error: Throwable,
-    ) {
-        writeAuditRecord(
-            runId = runId,
-            databaseStartTime = databaseStartTime,
-            catalogName = config.catalog,
-            databaseName = database,
-            status = STATUS_SKIPPED,
-            statusReason = "database_not_found",
-            errorMessage = error.message ?: error::class.java.name,
-        )
-    }
-
-    private fun writeFailedAuditRecord(
-        runId: String,
-        database: String,
-        databaseStartTime: Instant,
-        excludedPaths: List<String> = normalizedConfiguredExcludePaths(),
-        error: Throwable,
-    ) {
-        writeAuditRecord(
-            runId = runId,
-            databaseStartTime = databaseStartTime,
-            catalogName = config.catalog,
-            databaseName = database,
-            status = STATUS_FAILED,
-            statusReason = "unexpected_error",
-            errorMessage = error.message ?: error::class.java.name,
-            excludedPaths = excludedPaths,
-        )
-    }
-
     private fun normalizedConfiguredExcludePaths(): List<String> =
         config.excludePaths
             .map { StoragePathUtils.normalizeLocation(it) }
@@ -673,13 +435,4 @@ class CleanupUntrackedTableFoldersService {
             if (excludedDatabase != database) return@mapNotNull null
             StoragePathUtils.normalizeLocation("$storageScanLocation/$excludedFolder")
         }
-
-    private companion object {
-
-        const val OPERATION_DISCOVER_UNTRACKED_TABLE_FOLDERS = "DISCOVER_UNTRACKED_TABLE_FOLDERS"
-        const val STATUS_SUCCESS = "SUCCESS"
-        const val STATUS_SKIPPED = "SKIPPED"
-        const val STATUS_FAILED = "FAILED"
-        const val MAX_AUDIT_PATH_SAMPLE_SIZE = 100
-    }
 }

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/CandidateDeletionGate.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/CandidateDeletionGate.kt
@@ -1,0 +1,89 @@
+package com.iomete.cleanup.untrackedtablefolders.storage
+
+import com.iomete.cleanup.untrackedtablefolders.catalog.CatalogDiscoveryService
+import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jboss.logging.Logger
+
+@ApplicationScoped
+class CandidateDeletionGate {
+
+    private val logger = Logger.getLogger(CandidateDeletionGate::class.java)
+
+    @Inject lateinit var config: ApplicationConfig
+    @Inject lateinit var catalogDiscoveryService: CatalogDiscoveryService
+    @Inject lateinit var objectStorageDeletionService: ObjectStorageDeletionService
+
+    /**
+     * Returns the sorted list of folder paths that were actually deleted.
+     *
+     * Behavior:
+     *  - `dry_run=true` → returns emptyList, no catalog or storage I/O.
+     *  - `dry_run=false` AND `delete_enabled=false` → throws IllegalStateException.
+     *  - `dry_run=false` AND `delete_enabled=true` → re-queries the catalog for the
+     *    current active table locations and skips any candidate that now contains
+     *    (or is) an active table location. Surviving candidates are deleted
+     *    recursively via [ObjectStorageDeletionService]. The recheck is the
+     *    TOCTOU guard between detection and deletion.
+     */
+    fun deleteCandidates(
+        catalog: String,
+        database: String,
+        candidateFolders: List<StorageFolder>,
+    ): List<String> {
+        if (config.dryRun) {
+            return emptyList()
+        }
+
+        check(config.deleteEnabled) {
+            "delete_enabled must be true before deleting candidate folders"
+        }
+
+        if (candidateFolders.isEmpty()) {
+            return emptyList()
+        }
+
+        val currentActiveTableLocations = currentActiveTableLocations(catalog, database)
+
+        return candidateFolders
+            .mapNotNull { candidateFolder ->
+                deleteIfNotClaimedByActiveTable(candidateFolder, currentActiveTableLocations)
+            }
+            .sorted()
+    }
+
+    private fun currentActiveTableLocations(catalog: String, database: String): List<String> =
+        catalogDiscoveryService
+            .discoverDatabase(catalog = catalog, database = database)
+            .tables
+            .mapNotNull { it.location }
+            .map { StoragePathUtils.normalizeLocation(it) }
+
+    private fun deleteIfNotClaimedByActiveTable(
+        candidateFolder: StorageFolder,
+        currentActiveTableLocations: List<String>,
+    ): String? {
+        val normalizedCandidatePath = StoragePathUtils.normalizeLocation(candidateFolder.path)
+
+        val claimedByActiveTable =
+            currentActiveTableLocations.any { activeLocation ->
+                StoragePathUtils.isSameOrChildLocation(
+                    candidateLocation = activeLocation,
+                    rootLocation = normalizedCandidatePath,
+                )
+            }
+
+        if (claimedByActiveTable) {
+            logger.warn(
+                "Skipping deletion because candidate folder is or contains an active table location: path=${candidateFolder.path}"
+            )
+            return null
+        }
+
+        return objectStorageDeletionService
+            .deleteFolderRecursively(candidateFolder.path)
+            .takeIf { it.deleted }
+            ?.path
+    }
+}

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/CandidateSizeStatCollector.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/CandidateSizeStatCollector.kt
@@ -1,0 +1,64 @@
+package com.iomete.cleanup.untrackedtablefolders.storage
+
+import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jboss.logging.Logger
+
+@ApplicationScoped
+class CandidateSizeStatCollector {
+
+    private val logger = Logger.getLogger(CandidateSizeStatCollector::class.java)
+
+    @Inject lateinit var config: ApplicationConfig
+    @Inject lateinit var objectStorageDiscoveryService: ObjectStorageDiscoveryService
+
+    fun collectPerFolder(candidateFolderPaths: List<String>): Map<String, StorageSizeStats> {
+        if (candidateFolderPaths.isEmpty()) {
+            return emptyMap()
+        }
+
+        if (!config.collectSizeStatistics) {
+            logger.info(
+                "Skipping size statistics because collect_size_statistics=false. Candidate and deleted size audit fields will be NULL."
+            )
+            return emptyMap()
+        }
+
+        logger.info(
+            "Collecting size statistics for ${candidateFolderPaths.size} candidate folder(s). This may take time for folders with many objects. To skip this step, set collect_size_statistics=false."
+        )
+
+        val result = mutableMapOf<String, StorageSizeStats>()
+        var failedFolderCount = 0
+
+        candidateFolderPaths.forEach { candidateFolderPath ->
+            try {
+                result[candidateFolderPath] =
+                    objectStorageDiscoveryService.collectSizeStats(listOf(candidateFolderPath))
+            } catch (th: Throwable) {
+                failedFolderCount += 1
+                logger.warn(
+                    "Failed to collect size statistics for candidate folder; recording unknown size and continuing without aborting cleanup: path=$candidateFolderPath",
+                    th,
+                )
+            }
+        }
+
+        if (failedFolderCount > 0) {
+            logger.warn(
+                "Size statistics collection failed for $failedFolderCount of ${candidateFolderPaths.size} candidate folder(s). Candidate and deleted size audit fields exclude the failed folders."
+            )
+        }
+
+        return result
+    }
+
+    fun sum(stats: Iterable<StorageSizeStats>): StorageSizeStats =
+        stats.fold(StorageSizeStats.ZERO) { total, current ->
+            StorageSizeStats(
+                objectCount = total.objectCount + current.objectCount,
+                totalSizeBytes = total.totalSizeBytes + current.totalSizeBytes,
+            )
+        }
+}

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/ExcludePathResolver.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/ExcludePathResolver.kt
@@ -1,0 +1,49 @@
+package com.iomete.cleanup.untrackedtablefolders.storage
+
+import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+
+@ApplicationScoped
+class ExcludePathResolver {
+
+    @Inject lateinit var config: ApplicationConfig
+
+    fun normalizedConfiguredExcludePaths(): List<String> =
+        config.excludePaths
+            .map { StoragePathUtils.normalizeLocation(it) }
+            .distinct()
+            .sorted()
+
+    fun effectiveExcludedPaths(
+        database: String,
+        storageScanLocation: String,
+    ): List<String> {
+        val configuredExcludePaths = normalizedConfiguredExcludePaths()
+        val databaseFolderExcludePaths =
+            resolvedExcludeDatabaseFolderPaths(
+                database = database,
+                storageScanLocation = storageScanLocation,
+            )
+
+        return (configuredExcludePaths + databaseFolderExcludePaths)
+            .map { StoragePathUtils.normalizeLocation(it) }
+            .distinct()
+            .sorted()
+    }
+
+    private fun resolvedExcludeDatabaseFolderPaths(
+        database: String,
+        storageScanLocation: String,
+    ): List<String> =
+        config.excludeDatabaseFolders.mapNotNull { excludedDatabaseFolder ->
+            val parts = excludedDatabaseFolder.split(".", limit = 2)
+            if (parts.size != 2) return@mapNotNull null
+
+            val excludedDatabase = parts[0]
+            val excludedFolder = parts[1]
+
+            if (excludedDatabase != database) return@mapNotNull null
+            StoragePathUtils.normalizeLocation("$storageScanLocation/$excludedFolder")
+        }
+}

--- a/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/StorageScanLocationResolver.kt
+++ b/cleanup-untracked-table-folders-job/src/main/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/StorageScanLocationResolver.kt
@@ -1,0 +1,66 @@
+package com.iomete.cleanup.untrackedtablefolders.storage
+
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+
+@ApplicationScoped
+class StorageScanLocationResolver {
+
+    private val logger = Logger.getLogger(StorageScanLocationResolver::class.java)
+
+    fun resolve(
+        databaseLocation: String,
+        activeTableLocations: List<String>,
+    ): String {
+        val inferredScanLocations =
+            activeTableLocations.mapNotNull { parentLocation(it) }.distinct().sorted()
+
+        val resolvedScanLocation =
+            when (inferredScanLocations.size) {
+                0 -> {
+                    logger.warn(
+                        "No active table locations were discovered for databaseLocation=$databaseLocation. Falling back to discovered database location for storage scan. This may miss untracked folders if the database location differs from the actual table storage root."
+                    )
+                    databaseLocation
+                }
+                1 -> inferredScanLocations.single()
+                else -> {
+                    logger.warn(
+                        "Multiple active table parent locations were discovered for databaseLocation=$databaseLocation: $inferredScanLocations. Falling back to database location."
+                    )
+                    databaseLocation
+                }
+            }
+
+        validateStorageScanLocation(
+            databaseLocation = databaseLocation,
+            storageScanLocation = resolvedScanLocation,
+        )
+
+        return resolvedScanLocation
+    }
+
+    private fun validateStorageScanLocation(
+        databaseLocation: String,
+        storageScanLocation: String,
+    ) {
+        val allowedRoots = StoragePathUtils.allowedDatabaseRoots(databaseLocation)
+
+        if (!StoragePathUtils.isInsideAnyRoot(storageScanLocation, allowedRoots)) {
+            throw IllegalStateException(
+                "Resolved storage scan location escapes database boundary. databaseLocation=$databaseLocation, storageScanLocation=$storageScanLocation, allowedRoots=$allowedRoots"
+            )
+        }
+    }
+
+    private fun parentLocation(location: String): String? {
+        val normalizedLocation = location.trim().trimEnd('/')
+        val lastSlashIndex = normalizedLocation.lastIndexOf('/')
+
+        return if (lastSlashIndex <= 0) {
+            null
+        } else {
+            normalizedLocation.substring(0, lastSlashIndex)
+        }
+    }
+}

--- a/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditDiagnosticDetailsBuilderTest.kt
+++ b/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/audit/CleanupAuditDiagnosticDetailsBuilderTest.kt
@@ -1,0 +1,116 @@
+package com.iomete.cleanup.untrackedtablefolders.audit
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CleanupAuditDiagnosticDetailsBuilderTest {
+
+    private val builder = CleanupAuditDiagnosticDetailsBuilder()
+
+    @Test
+    fun `always emits active table location sample and truncation flag`() {
+        val details = builder.build(activeTableLocations = emptyList())
+
+        assertEquals("", details["active_table_locations_sample"])
+        assertEquals("false", details["active_table_locations_truncated"])
+        assertEquals(setOf("active_table_locations_sample", "active_table_locations_truncated"), details.keys)
+    }
+
+    @Test
+    fun `adds storage folder section only when storage folder paths are present`() {
+        val withStorage = builder.build(
+            activeTableLocations = listOf("s3a://bucket/db/active_table"),
+            storageFolderPaths = listOf("s3a://bucket/db/orphan"),
+        )
+
+        assertTrue(withStorage.containsKey("storage_folder_paths_sample"))
+        assertTrue(withStorage.containsKey("storage_folder_paths_truncated"))
+
+        val withoutStorage = builder.build(
+            activeTableLocations = listOf("s3a://bucket/db/active_table"),
+        )
+
+        assertFalse(withoutStorage.containsKey("storage_folder_paths_sample"))
+        assertFalse(withoutStorage.containsKey("storage_folder_paths_truncated"))
+    }
+
+    @Test
+    fun `adds candidate folder section only when candidate paths are present`() {
+        val withCandidates = builder.build(
+            activeTableLocations = emptyList(),
+            candidateFolderPaths = listOf("s3a://bucket/db/orphan"),
+        )
+
+        assertTrue(withCandidates.containsKey("candidate_folder_paths_sample"))
+        assertTrue(withCandidates.containsKey("candidate_folder_paths_truncated"))
+
+        val withoutCandidates = builder.build(activeTableLocations = emptyList())
+
+        assertFalse(withoutCandidates.containsKey("candidate_folder_paths_sample"))
+        assertFalse(withoutCandidates.containsKey("candidate_folder_paths_truncated"))
+    }
+
+    @Test
+    fun `adds non candidate storage folder section only when paths are present`() {
+        val withNonCandidates = builder.build(
+            activeTableLocations = emptyList(),
+            nonCandidateStorageFolderPaths = listOf("s3a://bucket/db/active_table"),
+        )
+
+        assertTrue(withNonCandidates.containsKey("non_candidate_storage_folder_paths_sample"))
+        assertTrue(withNonCandidates.containsKey("non_candidate_storage_folder_paths_truncated"))
+
+        val withoutNonCandidates = builder.build(activeTableLocations = emptyList())
+
+        assertFalse(withoutNonCandidates.containsKey("non_candidate_storage_folder_paths_sample"))
+        assertFalse(withoutNonCandidates.containsKey("non_candidate_storage_folder_paths_truncated"))
+    }
+
+    @Test
+    fun `truncates samples to first 100 paths and flags truncation`() {
+        val manyPaths = (1..150).map { "s3a://bucket/db/folder_${"%03d".format(it)}" }
+
+        val details = builder.build(activeTableLocations = manyPaths)
+
+        val sample = details["active_table_locations_sample"]!!.split("\n")
+        assertEquals(100, sample.size)
+        assertEquals("s3a://bucket/db/folder_001", sample.first())
+        assertEquals("s3a://bucket/db/folder_100", sample.last())
+        assertEquals("true", details["active_table_locations_truncated"])
+    }
+
+    @Test
+    fun `does not flag truncation when sample size exactly matches limit`() {
+        val exactlyHundredPaths = (1..100).map { "s3a://bucket/db/folder_${"%03d".format(it)}" }
+
+        val details = builder.build(activeTableLocations = exactlyHundredPaths)
+
+        assertEquals("false", details["active_table_locations_truncated"])
+    }
+
+    @Test
+    fun `emits all four sections when every input is populated`() {
+        val details = builder.build(
+            activeTableLocations = listOf("s3a://bucket/db/active"),
+            storageFolderPaths = listOf("s3a://bucket/db/active", "s3a://bucket/db/orphan"),
+            candidateFolderPaths = listOf("s3a://bucket/db/orphan"),
+            nonCandidateStorageFolderPaths = listOf("s3a://bucket/db/active"),
+        )
+
+        assertEquals(
+            setOf(
+                "active_table_locations_sample",
+                "active_table_locations_truncated",
+                "storage_folder_paths_sample",
+                "storage_folder_paths_truncated",
+                "candidate_folder_paths_sample",
+                "candidate_folder_paths_truncated",
+                "non_candidate_storage_folder_paths_sample",
+                "non_candidate_storage_folder_paths_truncated",
+            ),
+            details.keys,
+        )
+    }
+}

--- a/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersServiceTest.kt
+++ b/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/service/CleanupUntrackedTableFoldersServiceTest.kt
@@ -1,0 +1,419 @@
+package com.iomete.cleanup.untrackedtablefolders.service
+
+import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditRecorder
+import com.iomete.cleanup.untrackedtablefolders.audit.CleanupAuditTableService
+import com.iomete.cleanup.untrackedtablefolders.candidate.UntrackedFolderCandidateDetector
+import com.iomete.cleanup.untrackedtablefolders.catalog.CatalogDiscoveryService
+import com.iomete.cleanup.untrackedtablefolders.catalog.DatabaseNotFoundException
+import com.iomete.cleanup.untrackedtablefolders.catalog.DiscoveredDatabase
+import com.iomete.cleanup.untrackedtablefolders.catalog.DiscoveredTable
+import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import com.iomete.cleanup.untrackedtablefolders.logging.CleanupSummaryLogger
+import com.iomete.cleanup.untrackedtablefolders.storage.CandidateDeletionGate
+import com.iomete.cleanup.untrackedtablefolders.storage.CandidateSizeStatCollector
+import com.iomete.cleanup.untrackedtablefolders.storage.ExcludePathResolver
+import com.iomete.cleanup.untrackedtablefolders.storage.ObjectStorageDiscoveryService
+import com.iomete.cleanup.untrackedtablefolders.storage.StorageFolder
+import com.iomete.cleanup.untrackedtablefolders.storage.StorageScanLocationResolver
+import com.iomete.cleanup.untrackedtablefolders.storage.StorageSizeStats
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Wiring/integration test for [CleanupUntrackedTableFoldersService.run].
+ *
+ * I/O collaborators (catalog discovery, storage discovery, audit table writer,
+ * size collector, deletion gate) are mocked. Pure-logic collaborators (detector,
+ * scan resolver, exclude resolver, summary logger, audit recorder) are real
+ * instances. The test verifies that for each input scenario the orchestrator
+ * routes through the correct audit recorder method and gates deletion correctly.
+ */
+class CleanupUntrackedTableFoldersServiceTest {
+
+    private val catalogDiscoveryService = mockk<CatalogDiscoveryService>(relaxed = true)
+    private val objectStorageDiscoveryService = mockk<ObjectStorageDiscoveryService>(relaxed = true)
+    private val cleanupAuditTableService = mockk<CleanupAuditTableService>(relaxed = true)
+    private val cleanupAuditRecorder = mockk<CleanupAuditRecorder>(relaxed = true)
+    private val candidateSizeStatCollector = mockk<CandidateSizeStatCollector>(relaxed = true)
+    private val candidateDeletionGate = mockk<CandidateDeletionGate>(relaxed = true)
+
+    @BeforeEach
+    fun resetMocks() {
+        clearMocks(
+            catalogDiscoveryService,
+            objectStorageDiscoveryService,
+            cleanupAuditTableService,
+            cleanupAuditRecorder,
+            candidateSizeStatCollector,
+            candidateDeletionGate,
+        )
+        every { candidateSizeStatCollector.collectPerFolder(any()) } returns emptyMap()
+        every { candidateSizeStatCollector.sum(any()) } returns StorageSizeStats.ZERO
+        every { candidateDeletionGate.deleteCandidates(any(), any(), any()) } returns emptyList()
+    }
+
+    @Test
+    fun `dry-run happy path detects untracked folder, gates deletion, records success`() {
+        val service = serviceFor(
+            applicationConfig(dryRun = true, deleteEnabled = false, databases = listOf("analytics")),
+        )
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            discoveredDatabase(activeTableLocations = listOf("s3a://bucket/db/active_table"))
+        every { objectStorageDiscoveryService.listImmediateChildFolders("s3a://bucket/db") } returns
+            listOf(
+                storageFolder("s3a://bucket/db/active_table"),
+                storageFolder("s3a://bucket/db/orphan"),
+            )
+
+        service.run()
+
+        verify(exactly = 1) {
+            candidateDeletionGate.deleteCandidates(
+                catalog = "spark_catalog",
+                database = "analytics",
+                candidateFolders = match { folders ->
+                    folders.map { it.path } == listOf("s3a://bucket/db/orphan")
+                },
+            )
+        }
+        verify(exactly = 1) {
+            cleanupAuditRecorder.recordSuccess(
+                runId = any(),
+                databaseStartTime = any(),
+                catalogName = "spark_catalog",
+                databaseName = "analytics",
+                discoveredDatabaseLocation = "s3a://bucket/db",
+                storageScanLocation = "s3a://bucket/db",
+                activeTableCount = 1,
+                activeTableLocations = listOf("s3a://bucket/db/active_table"),
+                storageFolderPaths = listOf("s3a://bucket/db/active_table", "s3a://bucket/db/orphan"),
+                candidateFolderPaths = listOf("s3a://bucket/db/orphan"),
+                candidateSizeStats = any(),
+                deletedFolderPaths = emptyList(),
+                deletedSizeStats = any(),
+                cutoffTime = any(),
+                excludedPaths = emptyList(),
+            )
+        }
+        verifyNoOtherAuditCalls()
+    }
+
+    @Test
+    fun `delete-enabled happy path passes candidates to gate and records gate result in audit`() {
+        val service = serviceFor(
+            applicationConfig(dryRun = false, deleteEnabled = true, databases = listOf("analytics")),
+        )
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            discoveredDatabase(activeTableLocations = listOf("s3a://bucket/db/active_table"))
+        every { objectStorageDiscoveryService.listImmediateChildFolders("s3a://bucket/db") } returns
+            listOf(
+                storageFolder("s3a://bucket/db/active_table"),
+                storageFolder("s3a://bucket/db/orphan_a"),
+                storageFolder("s3a://bucket/db/orphan_b"),
+            )
+        every {
+            candidateDeletionGate.deleteCandidates(
+                catalog = "spark_catalog",
+                database = "analytics",
+                candidateFolders = any(),
+            )
+        } returns listOf("s3a://bucket/db/orphan_a", "s3a://bucket/db/orphan_b")
+
+        service.run()
+
+        verify(exactly = 1) {
+            cleanupAuditRecorder.recordSuccess(
+                runId = any(),
+                databaseStartTime = any(),
+                catalogName = "spark_catalog",
+                databaseName = "analytics",
+                discoveredDatabaseLocation = any(),
+                storageScanLocation = any(),
+                activeTableCount = any(),
+                activeTableLocations = any(),
+                storageFolderPaths = any(),
+                candidateFolderPaths = listOf("s3a://bucket/db/orphan_a", "s3a://bucket/db/orphan_b"),
+                candidateSizeStats = any(),
+                deletedFolderPaths = listOf("s3a://bucket/db/orphan_a", "s3a://bucket/db/orphan_b"),
+                deletedSizeStats = any(),
+                cutoffTime = any(),
+                excludedPaths = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `empty database records SKIPPED and never invokes deletion gate`() {
+        val service = serviceFor(
+            applicationConfig(dryRun = false, deleteEnabled = true, databases = listOf("empty_db")),
+        )
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "empty_db") } returns
+            DiscoveredDatabase(
+                catalog = "spark_catalog",
+                database = "empty_db",
+                location = "s3a://bucket/empty",
+                tables = emptyList(),
+            )
+
+        service.run()
+
+        verify(exactly = 1) {
+            cleanupAuditRecorder.recordNoActiveTables(
+                runId = any(),
+                databaseStartTime = any(),
+                catalogName = "spark_catalog",
+                databaseName = "empty_db",
+                discoveredDatabaseLocation = "s3a://bucket/empty",
+                excludedPaths = any(),
+            )
+        }
+        verify(exactly = 0) { candidateDeletionGate.deleteCandidates(any(), any(), any()) }
+        verify(exactly = 0) { objectStorageDiscoveryService.listImmediateChildFolders(any()) }
+        verifyNoOtherAuditCalls(except = "recordNoActiveTables")
+    }
+
+    @Test
+    fun `missing database location records SKIPPED with database_location_missing and skips storage scan`() {
+        val service = serviceFor(
+            applicationConfig(dryRun = false, deleteEnabled = true, databases = listOf("analytics")),
+        )
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            DiscoveredDatabase(
+                catalog = "spark_catalog",
+                database = "analytics",
+                location = null,
+                tables = listOf(activeTable("s3a://bucket/db/active_table")),
+            )
+
+        service.run()
+
+        verify(exactly = 1) {
+            cleanupAuditRecorder.recordDatabaseLocationMissing(
+                runId = any(),
+                databaseStartTime = any(),
+                catalogName = "spark_catalog",
+                databaseName = "analytics",
+                discoveredDatabaseLocation = null,
+                activeTableCount = 1,
+                activeTableLocations = listOf("s3a://bucket/db/active_table"),
+                errorMessage = any(),
+                excludedPaths = any(),
+            )
+        }
+        verify(exactly = 0) { objectStorageDiscoveryService.listImmediateChildFolders(any()) }
+        verify(exactly = 0) { candidateDeletionGate.deleteCandidates(any(), any(), any()) }
+        verifyNoOtherAuditCalls(except = "recordDatabaseLocationMissing")
+    }
+
+    @Test
+    fun `database not found exception routes to recordDatabaseNotFound`() {
+        val service = serviceFor(
+            applicationConfig(dryRun = true, deleteEnabled = false, databases = listOf("missing_db")),
+        )
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "missing_db") } throws
+            DatabaseNotFoundException(
+                catalog = "spark_catalog",
+                database = "missing_db",
+                cause = RuntimeException("simulated catalog miss"),
+            )
+
+        service.run()
+
+        verify(exactly = 1) {
+            cleanupAuditRecorder.recordDatabaseNotFound(
+                runId = any(),
+                database = "missing_db",
+                databaseStartTime = any(),
+                error = any(),
+            )
+        }
+        verify(exactly = 0) { candidateDeletionGate.deleteCandidates(any(), any(), any()) }
+        verifyNoOtherAuditCalls(except = "recordDatabaseNotFound")
+    }
+
+    @Test
+    fun `unexpected exception during processing routes to recordFailed`() {
+        val service = serviceFor(
+            applicationConfig(dryRun = true, deleteEnabled = false, databases = listOf("analytics")),
+        )
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            discoveredDatabase(activeTableLocations = listOf("s3a://bucket/db/active_table"))
+        every { objectStorageDiscoveryService.listImmediateChildFolders(any()) } throws
+            IllegalStateException("simulated storage list failure")
+
+        service.run()
+
+        verify(exactly = 1) {
+            cleanupAuditRecorder.recordFailed(
+                runId = any(),
+                database = "analytics",
+                databaseStartTime = any(),
+                excludedPaths = any(),
+                error = any(),
+            )
+        }
+        verify(exactly = 0) { candidateDeletionGate.deleteCandidates(any(), any(), any()) }
+        verifyNoOtherAuditCalls(except = "recordFailed")
+    }
+
+    @Test
+    fun `multiple databases isolate failures and produce one audit row per database with shared run id`() {
+        val service = serviceFor(
+            applicationConfig(
+                dryRun = true,
+                deleteEnabled = false,
+                databases = listOf("good_db", "missing_db", "another_good_db"),
+            ),
+        )
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "good_db") } returns
+            discoveredDatabase(
+                database = "good_db",
+                location = "s3a://bucket/good",
+                activeTableLocations = listOf("s3a://bucket/good/active_table"),
+            )
+        every { objectStorageDiscoveryService.listImmediateChildFolders("s3a://bucket/good") } returns
+            listOf(storageFolder("s3a://bucket/good/active_table"))
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "missing_db") } throws
+            DatabaseNotFoundException(
+                catalog = "spark_catalog",
+                database = "missing_db",
+                cause = RuntimeException("simulated catalog miss"),
+            )
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "another_good_db") } returns
+            discoveredDatabase(
+                database = "another_good_db",
+                location = "s3a://bucket/another_good",
+                activeTableLocations = listOf("s3a://bucket/another_good/active_table"),
+            )
+        every { objectStorageDiscoveryService.listImmediateChildFolders("s3a://bucket/another_good") } returns
+            listOf(storageFolder("s3a://bucket/another_good/active_table"))
+
+        val capturedRunIds = mutableSetOf<String>()
+        every {
+            cleanupAuditRecorder.recordSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } answers {
+            capturedRunIds.add(firstArg<String>())
+            Unit
+        }
+        every {
+            cleanupAuditRecorder.recordDatabaseNotFound(any(), any(), any(), any())
+        } answers {
+            capturedRunIds.add(firstArg<String>())
+            Unit
+        }
+
+        service.run()
+
+        verify(exactly = 2) {
+            cleanupAuditRecorder.recordSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+        verify(exactly = 1) {
+            cleanupAuditRecorder.recordDatabaseNotFound(any(), any(), any(), any())
+        }
+        assertEquals(1, capturedRunIds.size, "All databases in one run share one runId")
+    }
+
+    private fun verifyNoOtherAuditCalls(except: String = "recordSuccess") {
+        if (except != "recordNoActiveTables") {
+            verify(exactly = 0) {
+                cleanupAuditRecorder.recordNoActiveTables(any(), any(), any(), any(), any(), any())
+            }
+        }
+        if (except != "recordDatabaseLocationMissing") {
+            verify(exactly = 0) {
+                cleanupAuditRecorder.recordDatabaseLocationMissing(any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
+        }
+        if (except != "recordTooManyCandidateFolders") {
+            verify(exactly = 0) {
+                cleanupAuditRecorder.recordTooManyCandidateFolders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
+        }
+        if (except != "recordDatabaseNotFound") {
+            verify(exactly = 0) {
+                cleanupAuditRecorder.recordDatabaseNotFound(any(), any(), any(), any())
+            }
+        }
+        if (except != "recordFailed") {
+            verify(exactly = 0) {
+                cleanupAuditRecorder.recordFailed(any(), any(), any(), any(), any())
+            }
+        }
+        if (except != "recordSuccess") {
+            verify(exactly = 0) {
+                cleanupAuditRecorder.recordSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
+        }
+    }
+
+    private fun serviceFor(applicationConfig: ApplicationConfig): CleanupUntrackedTableFoldersService {
+        val excludePathResolver = ExcludePathResolver().apply { config = applicationConfig }
+        return CleanupUntrackedTableFoldersService().apply {
+            config = applicationConfig
+            catalogDiscoveryService = this@CleanupUntrackedTableFoldersServiceTest.catalogDiscoveryService
+            objectStorageDiscoveryService = this@CleanupUntrackedTableFoldersServiceTest.objectStorageDiscoveryService
+            untrackedFolderCandidateDetector = UntrackedFolderCandidateDetector()
+            cleanupAuditTableService = this@CleanupUntrackedTableFoldersServiceTest.cleanupAuditTableService
+            cleanupAuditRecorder = this@CleanupUntrackedTableFoldersServiceTest.cleanupAuditRecorder
+            cleanupSummaryLogger = CleanupSummaryLogger()
+            storageScanLocationResolver = StorageScanLocationResolver()
+            this.excludePathResolver = excludePathResolver
+            candidateSizeStatCollector = this@CleanupUntrackedTableFoldersServiceTest.candidateSizeStatCollector
+            candidateDeletionGate = this@CleanupUntrackedTableFoldersServiceTest.candidateDeletionGate
+        }
+    }
+
+    private fun applicationConfig(
+        dryRun: Boolean,
+        deleteEnabled: Boolean,
+        databases: List<String>,
+    ): ApplicationConfig =
+        ApplicationConfig(
+            catalog = "spark_catalog",
+            databases = databases,
+            dryRun = dryRun,
+            deleteEnabled = deleteEnabled,
+            // older_than_hours defaults to 24, but we want every storage folder eligible
+            // regardless of mod time in these tests, so pretend everything is ancient.
+            olderThanHours = 0,
+        )
+
+    private fun storageFolder(path: String): StorageFolder =
+        StorageFolder(
+            path = path,
+            // mod time deep in the past so the detector never filters on age
+            modificationTimeMillis = 0,
+        )
+
+    private fun discoveredDatabase(
+        database: String = "analytics",
+        location: String = "s3a://bucket/db",
+        activeTableLocations: List<String>,
+    ): DiscoveredDatabase =
+        DiscoveredDatabase(
+            catalog = "spark_catalog",
+            database = database,
+            location = location,
+            tables = activeTableLocations.mapIndexed { index, tableLocation ->
+                activeTable(tableLocation, name = "table_$index", database = database)
+            },
+        )
+
+    private fun activeTable(
+        location: String,
+        name: String = "table_0",
+        database: String = "analytics",
+    ): DiscoveredTable =
+        DiscoveredTable(
+            catalog = "spark_catalog",
+            database = database,
+            table = name,
+            isTemporary = false,
+            location = location,
+        )
+}

--- a/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/CandidateDeletionGateTest.kt
+++ b/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/CandidateDeletionGateTest.kt
@@ -1,0 +1,255 @@
+package com.iomete.cleanup.untrackedtablefolders.storage
+
+import com.iomete.cleanup.untrackedtablefolders.catalog.CatalogDiscoveryService
+import com.iomete.cleanup.untrackedtablefolders.catalog.DiscoveredDatabase
+import com.iomete.cleanup.untrackedtablefolders.catalog.DiscoveredTable
+import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class CandidateDeletionGateTest {
+
+    private val catalogDiscoveryService = mockk<CatalogDiscoveryService>(relaxed = true)
+    private val objectStorageDeletionService = mockk<ObjectStorageDeletionService>(relaxed = true)
+
+    @Test
+    fun `returns empty list and performs no IO when dry_run is true`() {
+        val gate = gateFor(
+            config = applicationConfig(dryRun = true, deleteEnabled = true),
+        )
+
+        val result = gate.deleteCandidates(
+            catalog = "spark_catalog",
+            database = "analytics",
+            candidateFolders = listOf(
+                storageFolder("s3a://bucket/db/orphan_a"),
+                storageFolder("s3a://bucket/db/orphan_b"),
+            ),
+        )
+
+        assertEquals(emptyList<String>(), result)
+        verify(exactly = 0) { catalogDiscoveryService.discoverDatabase(any(), any()) }
+        verify(exactly = 0) { objectStorageDeletionService.deleteFolderRecursively(any()) }
+    }
+
+    @Test
+    fun `throws when delete is not dry_run but delete_enabled is false`() {
+        val gate = gateFor(
+            config = applicationConfig(dryRun = false, deleteEnabled = false),
+        )
+
+        val error = assertThrows(IllegalStateException::class.java) {
+            gate.deleteCandidates(
+                catalog = "spark_catalog",
+                database = "analytics",
+                candidateFolders = listOf(storageFolder("s3a://bucket/db/orphan_a")),
+            )
+        }
+
+        assertEquals(
+            "delete_enabled must be true before deleting candidate folders",
+            error.message,
+        )
+        verify(exactly = 0) { catalogDiscoveryService.discoverDatabase(any(), any()) }
+        verify(exactly = 0) { objectStorageDeletionService.deleteFolderRecursively(any()) }
+    }
+
+    @Test
+    fun `returns empty list and performs no catalog or storage calls when candidate list is empty`() {
+        val gate = gateFor(
+            config = applicationConfig(dryRun = false, deleteEnabled = true),
+        )
+
+        val result = gate.deleteCandidates(
+            catalog = "spark_catalog",
+            database = "analytics",
+            candidateFolders = emptyList(),
+        )
+
+        assertEquals(emptyList<String>(), result)
+        verify(exactly = 0) { catalogDiscoveryService.discoverDatabase(any(), any()) }
+        verify(exactly = 0) { objectStorageDeletionService.deleteFolderRecursively(any()) }
+    }
+
+    @Test
+    fun `deletes every candidate when none are reclaimed by the catalog`() {
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            discoveredDatabase(activeTableLocations = listOf("s3a://bucket/db/active_table"))
+        every { objectStorageDeletionService.deleteFolderRecursively(any()) } answers {
+            DeletedStorageFolder(path = firstArg(), deleted = true)
+        }
+
+        val gate = gateFor(
+            config = applicationConfig(dryRun = false, deleteEnabled = true),
+        )
+
+        val result = gate.deleteCandidates(
+            catalog = "spark_catalog",
+            database = "analytics",
+            candidateFolders = listOf(
+                storageFolder("s3a://bucket/db/orphan_b"),
+                storageFolder("s3a://bucket/db/orphan_a"),
+            ),
+        )
+
+        assertEquals(
+            listOf("s3a://bucket/db/orphan_a", "s3a://bucket/db/orphan_b"),
+            result,
+        )
+        verify(exactly = 1) { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/orphan_a") }
+        verify(exactly = 1) { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/orphan_b") }
+    }
+
+    @Test
+    fun `skips candidate when catalog now claims that exact path as an active table`() {
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            discoveredDatabase(
+                activeTableLocations = listOf(
+                    "s3a://bucket/db/active_table",
+                    "s3a://bucket/db/now_active",
+                ),
+            )
+        every { objectStorageDeletionService.deleteFolderRecursively(any()) } answers {
+            DeletedStorageFolder(path = firstArg(), deleted = true)
+        }
+
+        val gate = gateFor(
+            config = applicationConfig(dryRun = false, deleteEnabled = true),
+        )
+
+        val result = gate.deleteCandidates(
+            catalog = "spark_catalog",
+            database = "analytics",
+            candidateFolders = listOf(
+                storageFolder("s3a://bucket/db/now_active"),
+                storageFolder("s3a://bucket/db/still_orphan"),
+            ),
+        )
+
+        assertEquals(listOf("s3a://bucket/db/still_orphan"), result)
+        verify(exactly = 0) { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/now_active") }
+        verify(exactly = 1) { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/still_orphan") }
+    }
+
+    @Test
+    fun `skips candidate when catalog now has an active table nested below the candidate`() {
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            discoveredDatabase(
+                activeTableLocations = listOf("s3a://bucket/db/team_a/orders"),
+            )
+        every { objectStorageDeletionService.deleteFolderRecursively(any()) } answers {
+            DeletedStorageFolder(path = firstArg(), deleted = true)
+        }
+
+        val gate = gateFor(
+            config = applicationConfig(dryRun = false, deleteEnabled = true),
+        )
+
+        val result = gate.deleteCandidates(
+            catalog = "spark_catalog",
+            database = "analytics",
+            candidateFolders = listOf(
+                storageFolder("s3a://bucket/db/team_a"),
+                storageFolder("s3a://bucket/db/abandoned"),
+            ),
+        )
+
+        assertEquals(listOf("s3a://bucket/db/abandoned"), result)
+        verify(exactly = 0) { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/team_a") }
+        verify(exactly = 1) { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/abandoned") }
+    }
+
+    @Test
+    fun `excludes folder from returned list when deletion service reports not deleted`() {
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            discoveredDatabase(activeTableLocations = emptyList())
+        every { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/missing") } returns
+            DeletedStorageFolder(path = "s3a://bucket/db/missing", deleted = false)
+        every { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/present") } returns
+            DeletedStorageFolder(path = "s3a://bucket/db/present", deleted = true)
+
+        val gate = gateFor(
+            config = applicationConfig(dryRun = false, deleteEnabled = true),
+        )
+
+        val result = gate.deleteCandidates(
+            catalog = "spark_catalog",
+            database = "analytics",
+            candidateFolders = listOf(
+                storageFolder("s3a://bucket/db/missing"),
+                storageFolder("s3a://bucket/db/present"),
+            ),
+        )
+
+        assertEquals(listOf("s3a://bucket/db/present"), result)
+    }
+
+    @Test
+    fun `propagates deletion service exceptions without partial cleanup of remaining candidates`() {
+        every { catalogDiscoveryService.discoverDatabase("spark_catalog", "analytics") } returns
+            discoveredDatabase(activeTableLocations = emptyList())
+        every { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/orphan_a") } returns
+            DeletedStorageFolder(path = "s3a://bucket/db/orphan_a", deleted = true)
+        every { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/orphan_b") } throws
+            IllegalStateException("simulated FS error on delete")
+
+        val gate = gateFor(
+            config = applicationConfig(dryRun = false, deleteEnabled = true),
+        )
+
+        assertThrows(IllegalStateException::class.java) {
+            gate.deleteCandidates(
+                catalog = "spark_catalog",
+                database = "analytics",
+                candidateFolders = listOf(
+                    storageFolder("s3a://bucket/db/orphan_a"),
+                    storageFolder("s3a://bucket/db/orphan_b"),
+                    storageFolder("s3a://bucket/db/orphan_c"),
+                ),
+            )
+        }
+
+        verify(exactly = 0) { objectStorageDeletionService.deleteFolderRecursively("s3a://bucket/db/orphan_c") }
+    }
+
+    private fun gateFor(config: ApplicationConfig): CandidateDeletionGate =
+        CandidateDeletionGate().apply {
+            this.config = config
+            this.catalogDiscoveryService = this@CandidateDeletionGateTest.catalogDiscoveryService
+            this.objectStorageDeletionService = this@CandidateDeletionGateTest.objectStorageDeletionService
+        }
+
+    private fun applicationConfig(
+        dryRun: Boolean,
+        deleteEnabled: Boolean,
+    ): ApplicationConfig =
+        ApplicationConfig(
+            catalog = "spark_catalog",
+            databases = listOf("analytics"),
+            dryRun = dryRun,
+            deleteEnabled = deleteEnabled,
+        )
+
+    private fun storageFolder(path: String): StorageFolder =
+        StorageFolder(path = path, modificationTimeMillis = 0)
+
+    private fun discoveredDatabase(activeTableLocations: List<String>): DiscoveredDatabase =
+        DiscoveredDatabase(
+            catalog = "spark_catalog",
+            database = "analytics",
+            location = "s3a://bucket/db",
+            tables = activeTableLocations.mapIndexed { index, location ->
+                DiscoveredTable(
+                    catalog = "spark_catalog",
+                    database = "analytics",
+                    table = "table_$index",
+                    isTemporary = false,
+                    location = location,
+                )
+            },
+        )
+}

--- a/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/ExcludePathResolverTest.kt
+++ b/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/ExcludePathResolverTest.kt
@@ -1,0 +1,111 @@
+package com.iomete.cleanup.untrackedtablefolders.storage
+
+import com.iomete.cleanup.untrackedtablefolders.config.ApplicationConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ExcludePathResolverTest {
+
+    @Test
+    fun `returns empty when no configured exclude paths`() {
+        val resolver = resolverFor(
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics"),
+            )
+        )
+
+        assertEquals(emptyList<String>(), resolver.normalizedConfiguredExcludePaths())
+    }
+
+    @Test
+    fun `normalizes scheme casing and trailing slash, then dedupes and sorts configured exclude paths`() {
+        val resolver = resolverFor(
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics"),
+                excludePaths = listOf(
+                    "s3a://bucket/db/zebra/",
+                    "S3A://bucket/db/zebra",
+                    "s3a://bucket/db/apple",
+                ),
+            )
+        )
+
+        assertEquals(
+            listOf(
+                "s3a://bucket/db/apple",
+                "s3a://bucket/db/zebra",
+            ),
+            resolver.normalizedConfiguredExcludePaths(),
+        )
+    }
+
+    @Test
+    fun `effective paths combines configured and database-folder paths and sorts them`() {
+        val resolver = resolverFor(
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics"),
+                excludePaths = listOf("s3a://bucket/db/external"),
+                excludeDatabaseFolders = listOf("analytics.customer_events"),
+            )
+        )
+
+        val result = resolver.effectiveExcludedPaths(
+            database = "analytics",
+            storageScanLocation = "s3a://bucket/db",
+        )
+
+        assertEquals(
+            listOf(
+                "s3a://bucket/db/customer_events",
+                "s3a://bucket/db/external",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `effective paths ignores database-folder entries for unrelated databases`() {
+        val resolver = resolverFor(
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics", "sales"),
+                excludeDatabaseFolders = listOf("sales.invoices"),
+            )
+        )
+
+        val result = resolver.effectiveExcludedPaths(
+            database = "analytics",
+            storageScanLocation = "s3a://bucket/db",
+        )
+
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun `effective paths dedupe when configured path matches resolved database-folder path`() {
+        val resolver = resolverFor(
+            ApplicationConfig(
+                catalog = "spark_catalog",
+                databases = listOf("analytics"),
+                excludePaths = listOf("s3a://bucket/db/customer_events"),
+                excludeDatabaseFolders = listOf("analytics.customer_events"),
+            )
+        )
+
+        val result = resolver.effectiveExcludedPaths(
+            database = "analytics",
+            storageScanLocation = "s3a://bucket/db",
+        )
+
+        assertEquals(
+            listOf("s3a://bucket/db/customer_events"),
+            result,
+        )
+    }
+
+    private fun resolverFor(applicationConfig: ApplicationConfig): ExcludePathResolver =
+        ExcludePathResolver().apply { config = applicationConfig }
+}

--- a/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/StorageScanLocationResolverTest.kt
+++ b/cleanup-untracked-table-folders-job/src/test/kotlin/com/iomete/cleanup/untrackedtablefolders/storage/StorageScanLocationResolverTest.kt
@@ -1,0 +1,104 @@
+package com.iomete.cleanup.untrackedtablefolders.storage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class StorageScanLocationResolverTest {
+
+    private val resolver = StorageScanLocationResolver()
+
+    @Test
+    fun `returns database location when active table locations are empty`() {
+        val result =
+            resolver.resolve(
+                databaseLocation = "s3a://bucket/data/delete_1.db",
+                activeTableLocations = emptyList(),
+            )
+
+        assertEquals("s3a://bucket/data/delete_1.db", result)
+    }
+
+    @Test
+    fun `returns parent of single active table location`() {
+        val result =
+            resolver.resolve(
+                databaseLocation = "s3a://bucket/data/delete_1.db",
+                activeTableLocations =
+                    listOf("s3a://bucket/data/delete_1/delete_table_a"),
+            )
+
+        assertEquals("s3a://bucket/data/delete_1", result)
+    }
+
+    @Test
+    fun `returns shared parent when all active table locations have the same parent`() {
+        val result =
+            resolver.resolve(
+                databaseLocation = "s3a://bucket/data/delete_1.db",
+                activeTableLocations =
+                    listOf(
+                        "s3a://bucket/data/delete_1/delete_table_a",
+                        "s3a://bucket/data/delete_1/delete_table_b",
+                        "s3a://bucket/data/delete_1/delete_table_c",
+                    ),
+            )
+
+        assertEquals("s3a://bucket/data/delete_1", result)
+    }
+
+    @Test
+    fun `falls back to database location when active table locations have different parents`() {
+        val result =
+            resolver.resolve(
+                databaseLocation = "s3a://bucket/data/default.db",
+                activeTableLocations =
+                    listOf(
+                        "s3a://bucket/data/default.db/table_a",
+                        "s3a://bucket/data/default/table_b",
+                        "s3a://bucket/data/DEFAULT/table_c",
+                    ),
+            )
+
+        assertEquals("s3a://bucket/data/default.db", result)
+    }
+
+    @Test
+    fun `allows non db sibling root for db database location`() {
+        val result =
+            resolver.resolve(
+                databaseLocation = "s3a://bucket/data/delete_1.db",
+                activeTableLocations =
+                    listOf("s3a://bucket/data/delete_1/delete_table_a"),
+            )
+
+        assertEquals("s3a://bucket/data/delete_1", result)
+    }
+
+    @Test
+    fun `throws when inferred scan location escapes database boundary`() {
+        val error =
+            assertThrows(IllegalStateException::class.java) {
+                resolver.resolve(
+                    databaseLocation = "s3a://bucket/data/delete_1.db",
+                    activeTableLocations =
+                        listOf("s3a://bucket/other/delete_table_a"),
+                )
+            }
+
+        assertTrue(error.message?.contains("escapes database boundary") == true)
+    }
+
+    @Test
+    fun `trims trailing slash from active table location before resolving parent`() {
+        val result =
+            resolver.resolve(
+                databaseLocation = "s3a://bucket/data/delete_1.db",
+                activeTableLocations =
+                    listOf("s3a://bucket/data/delete_1/delete_table_a/"),
+            )
+
+        assertEquals("s3a://bucket/data/delete_1", result)
+    }
+}


### PR DESCRIPTION
### Summary

Refactors the cleanup untracked table folders job to make the main service smaller, easier to review, and easier to test.

Main changes:
- Extracted storage scan root resolution into `StorageScanLocationResolver`
- Extracted exclude path handling into `ExcludePathResolver`
- Extracted candidate size calculation into `CandidateSizeStatCollector`
- Extracted delete execution and pre-delete active table recheck into `CandidateDeletionGate`
- Extracted cleanup summary logging into `CleanupSummaryLogger`
- Extracted audit record writing into `CleanupAuditRecorder`
- Extracted audit diagnostic map creation into `CleanupAuditDiagnosticDetailsBuilder`
- Added candidate skip reason logging for better runtime/debug visibility
- Added focused tests for resolver, exclude path handling, audit diagnostics, deletion gate, and service orchestration

### Notes

This is intended as a behavior-preserving refactor. The delete safety flow is preserved, including the pre-delete catalog recheck before recursive deletion.

### Validation

- `./gradlew clean test`
- `./gradlew clean quarkusBuild`