### PR TITLE
feat(catalog-sync): Iceberg fast-path extraction (PLA-461)

### DIFF
--- a/iomete-catalog-sync/Makefile
+++ b/iomete-catalog-sync/Makefile
@@ -1,5 +1,5 @@
 image := iomete.azurecr.io/iomete/iom-catalog-sync
-tag   := 5.0.2
+tag   := 5.0.3
 
 .PHONY: build
 build:

--- a/iomete-catalog-sync/build.gradle.kts
+++ b/iomete-catalog-sync/build.gradle.kts
@@ -52,6 +52,7 @@ allprojects {
 
         // Apache Spark
         compileOnly("org.apache.spark:spark-sql_2.12:3.5.7")
+        compileOnly("org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.7.1")
 
         // Test dependencies
         testImplementation("io.quarkus:quarkus-junit5")

--- a/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReader.kt
+++ b/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReader.kt
@@ -13,7 +13,6 @@ import org.apache.iceberg.types.Types
 import org.apache.spark.sql.SparkSession
 
 private const val ICEBERG_PROVIDER = "iceberg"
-private const val MANAGED_TABLE_TYPE = "MANAGED"
 private const val TABLE_COMMENT_PROPERTY = "comment"
 private const val TABLE_OWNER_PROPERTY = "owner"
 private const val PARTITION_SPEC_METADATA = "Partition Spec"
@@ -32,11 +31,23 @@ data class IcebergLoadedTableMetadata(
 
 @Singleton
 class IcebergMetadataReader {
-    private val tableLoader: (SparkSession, String, String, String) -> Table
+    private val tableLoader: (
+        spark: SparkSession,
+        catalog: String,
+        schema: String,
+        tableName: String,
+    ) -> Table
 
     constructor() : this(::loadIcebergTable)
 
-    internal constructor(tableLoader: (SparkSession, String, String, String) -> Table) {
+    internal constructor(
+        tableLoader: (
+            spark: SparkSession,
+            catalog: String,
+            schema: String,
+            tableName: String,
+        ) -> Table,
+    ) {
         this.tableLoader = tableLoader
     }
 
@@ -47,14 +58,14 @@ class IcebergMetadataReader {
         tableName: String,
     ): IcebergLoadedTableMetadata {
         val table = tableLoader(spark, catalog, schema, tableName)
-        val schema = table.schema()
-        val spec = table.spec()
+        val icebergSchema = table.schema()
+        val partitionSpec = table.spec()
         val properties = table.properties().orEmpty()
-        val partitionSourceIds = spec?.fields().orEmpty().map { it.sourceId() }.toSet()
+        val partitionSourceIds = partitionSpec?.fields().orEmpty().map { it.sourceId() }.toSet()
 
         return IcebergLoadedTableMetadata(
             tableDescription = TableDescription(
-                columns = schema.columns().mapIndexed { index, field ->
+                columns = icebergSchema.columns().mapIndexed { index, field ->
                     ColumnMetadata(
                         name = field.name(),
                         dataType = toSparkType(field.type()),
@@ -63,7 +74,7 @@ class IcebergMetadataReader {
                         isPartitionKey = field.fieldId() in partitionSourceIds,
                     )
                 },
-                metadata = buildMetadata(properties, partitionSpecString(schema, spec)),
+                metadata = buildMetadata(properties, partitionSpecString(icebergSchema, partitionSpec)),
             ),
             tableProperties = properties,
             statistics = extractStatistics(table),
@@ -75,7 +86,6 @@ class IcebergMetadataReader {
         partitionSpec: String,
     ): Map<String, String> =
         buildMap {
-            put("Type", MANAGED_TABLE_TYPE)
             put("Provider", ICEBERG_PROVIDER)
             properties[TABLE_COMMENT_PROPERTY]?.let { put("Comment", it) }
             properties[TABLE_OWNER_PROPERTY]?.let { put("Owner", it) }
@@ -122,6 +132,9 @@ class IcebergMetadataReader {
 
         if (addedValues.any { it == null }) return null
 
+        // Iceberg summaries expose a current total and per-snapshot added counts. Use the
+        // first available total as the baseline, then add later snapshot deltas only when
+        // every needed summary value exists; otherwise return null instead of guessing.
         return firstTotal + (addedValues.filterNotNull().sum() - firstAdded)
     }
 

--- a/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReader.kt
+++ b/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReader.kt
@@ -1,0 +1,187 @@
+package com.iomete.catalogsync.metadata
+
+import com.iomete.catalogsync.extract.TableStatistics
+import jakarta.inject.Singleton
+import org.apache.iceberg.PartitionSpec
+import org.apache.iceberg.Schema
+import org.apache.iceberg.Snapshot
+import org.apache.iceberg.Table
+import org.apache.iceberg.spark.Spark3Util
+import org.apache.iceberg.spark.SparkSchemaUtil
+import org.apache.iceberg.types.Type
+import org.apache.iceberg.types.Types
+import org.apache.spark.sql.SparkSession
+
+private const val ICEBERG_PROVIDER = "iceberg"
+private const val MANAGED_TABLE_TYPE = "MANAGED"
+private const val TABLE_COMMENT_PROPERTY = "comment"
+private const val TABLE_OWNER_PROPERTY = "owner"
+private const val PARTITION_SPEC_METADATA = "Partition Spec"
+
+private const val TOTAL_DATA_FILES = "total-data-files"
+private const val TOTAL_FILES_SIZE = "total-files-size"
+private const val TOTAL_RECORDS = "total-records"
+private const val ADDED_DATA_FILES = "added-data-files"
+private const val ADDED_FILES_SIZE = "added-files-size"
+
+data class IcebergLoadedTableMetadata(
+    val tableDescription: TableDescription,
+    val tableProperties: Map<String, String>,
+    val statistics: TableStatistics?,
+)
+
+@Singleton
+class IcebergMetadataReader {
+    private val tableLoader: (SparkSession, String, String, String) -> Table
+
+    constructor() : this(::loadIcebergTable)
+
+    internal constructor(tableLoader: (SparkSession, String, String, String) -> Table) {
+        this.tableLoader = tableLoader
+    }
+
+    fun loadTableMetadata(
+        spark: SparkSession,
+        catalog: String,
+        schema: String,
+        tableName: String,
+    ): IcebergLoadedTableMetadata {
+        val table = tableLoader(spark, catalog, schema, tableName)
+        val schema = table.schema()
+        val spec = table.spec()
+        val properties = table.properties().orEmpty()
+        val partitionSourceIds = spec?.fields().orEmpty().map { it.sourceId() }.toSet()
+
+        return IcebergLoadedTableMetadata(
+            tableDescription = TableDescription(
+                columns = schema.columns().mapIndexed { index, field ->
+                    ColumnMetadata(
+                        name = field.name(),
+                        dataType = toSparkType(field.type()),
+                        description = field.doc(),
+                        sortOrder = index,
+                        isPartitionKey = field.fieldId() in partitionSourceIds,
+                    )
+                },
+                metadata = buildMetadata(properties, partitionSpecString(schema, spec)),
+            ),
+            tableProperties = properties,
+            statistics = extractStatistics(table),
+        )
+    }
+
+    private fun buildMetadata(
+        properties: Map<String, String>,
+        partitionSpec: String,
+    ): Map<String, String> =
+        buildMap {
+            put("Type", MANAGED_TABLE_TYPE)
+            put("Provider", ICEBERG_PROVIDER)
+            properties[TABLE_COMMENT_PROPERTY]?.let { put("Comment", it) }
+            properties[TABLE_OWNER_PROPERTY]?.let { put("Owner", it) }
+            put("Table Properties", formatTableProperties(properties))
+            put(PARTITION_SPEC_METADATA, partitionSpec)
+        }
+
+    private fun extractStatistics(table: Table): TableStatistics? {
+        val currentSnapshot = table.currentSnapshot() ?: return null
+        val snapshots = table.snapshots().toList().ifEmpty { listOf(currentSnapshot) }
+        val firstSnapshot = snapshots.minByOrNull { it.timestampMillis() } ?: currentSnapshot
+        val currentSummary = currentSnapshot.summary().orEmpty()
+
+        return TableStatistics(
+            lastModified = currentSnapshot.timestampMillis(),
+            numFiles = currentSummary.longValue(TOTAL_DATA_FILES),
+            totalTableNumFiles = historicalTotalFromAvailableSummaries(
+                snapshots = snapshots,
+                firstSnapshot = firstSnapshot,
+                totalKey = TOTAL_DATA_FILES,
+                addedKey = ADDED_DATA_FILES,
+            ),
+            sizeInBytes = currentSummary.longValue(TOTAL_FILES_SIZE),
+            totalTableSizeInBytes = historicalTotalFromAvailableSummaries(
+                snapshots = snapshots,
+                firstSnapshot = firstSnapshot,
+                totalKey = TOTAL_FILES_SIZE,
+                addedKey = ADDED_FILES_SIZE,
+            ),
+            totalRecords = currentSummary.longValue(TOTAL_RECORDS),
+        )
+    }
+
+    private fun historicalTotalFromAvailableSummaries(
+        snapshots: List<Snapshot>,
+        firstSnapshot: Snapshot,
+        totalKey: String,
+        addedKey: String,
+    ): Long? {
+        val firstSummary = firstSnapshot.summary().orEmpty()
+        val firstTotal = firstSummary.longValue(totalKey) ?: return null
+        val firstAdded = firstSummary.longValue(addedKey) ?: return null
+        val addedValues = snapshots.map { it.summary().orEmpty().longValue(addedKey) }
+
+        if (addedValues.any { it == null }) return null
+
+        return firstTotal + (addedValues.filterNotNull().sum() - firstAdded)
+    }
+
+    private fun Map<String, String>.longValue(key: String): Long? = this[key]?.toLongOrNull()
+}
+
+private fun toSparkType(type: Type): String =
+    when (type.typeId()) {
+        Type.TypeID.TIME -> throw UnsupportedOperationException("Spark does not support Iceberg time fields")
+        Type.TypeID.TIMESTAMP -> {
+            val timestamp = type.asPrimitiveType() as Types.TimestampType
+            sparkTimestampType(timestamp.shouldAdjustToUTC())
+        }
+        Type.TypeID.TIMESTAMP_NANO -> {
+            val timestamp = type.asPrimitiveType() as Types.TimestampNanoType
+            sparkTimestampType(timestamp.shouldAdjustToUTC())
+        }
+        else -> SparkSchemaUtil.convert(type).catalogString()
+    }
+
+private fun sparkTimestampType(shouldAdjustToUTC: Boolean): String =
+    if (shouldAdjustToUTC) {
+        "timestamp"
+    } else {
+        "timestamp_ntz"
+    }
+
+private fun partitionSpecString(
+    schema: Schema,
+    spec: PartitionSpec?,
+): String {
+    val fields = spec?.fields().orEmpty()
+    if (fields.isEmpty()) return "[]"
+
+    return fields.joinToString(", ") { field ->
+        val sourceName = schema.findColumnName(field.sourceId()) ?: field.sourceId().toString()
+        if (field.transform().isIdentity) {
+            sourceName
+        } else {
+            "${field.transform()}($sourceName)"
+        }
+    }
+}
+
+private fun loadIcebergTable(
+    spark: SparkSession,
+    catalog: String,
+    schema: String,
+    tableName: String,
+): Table = Spark3Util.loadIcebergTable(spark, quotedFullName(catalog, schema, tableName))
+
+private fun quotedFullName(vararg parts: String): String =
+    parts.joinToString(".") { part -> "`${part.replace("`", "``")}`" }
+
+private fun formatTableProperties(properties: Map<String, String>): String =
+    if (properties.isEmpty()) {
+        "[]"
+    } else {
+        properties
+            .toSortedMap()
+            .entries
+            .joinToString(prefix = "[", postfix = "]") { (key, value) -> "$key=$value" }
+    }

--- a/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReader.kt
+++ b/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReader.kt
@@ -34,7 +34,7 @@ class IcebergMetadataReader {
     private val tableLoader: (
         spark: SparkSession,
         catalog: String,
-        schema: String,
+        schemaName: String,
         tableName: String,
     ) -> Table
 
@@ -44,7 +44,7 @@ class IcebergMetadataReader {
         tableLoader: (
             spark: SparkSession,
             catalog: String,
-            schema: String,
+            schemaName: String,
             tableName: String,
         ) -> Table,
     ) {
@@ -54,10 +54,10 @@ class IcebergMetadataReader {
     fun loadTableMetadata(
         spark: SparkSession,
         catalog: String,
-        schema: String,
+        schemaName: String,
         tableName: String,
     ): IcebergLoadedTableMetadata {
-        val table = tableLoader(spark, catalog, schema, tableName)
+        val table = tableLoader(spark, catalog, schemaName, tableName)
         val icebergSchema = table.schema()
         val partitionSpec = table.spec()
         val properties = table.properties().orEmpty()
@@ -161,14 +161,14 @@ private fun sparkTimestampType(shouldAdjustToUTC: Boolean): String =
     }
 
 private fun partitionSpecString(
-    schema: Schema,
+    icebergSchema: Schema,
     spec: PartitionSpec?,
 ): String {
     val fields = spec?.fields().orEmpty()
     if (fields.isEmpty()) return "[]"
 
     return fields.joinToString(", ") { field ->
-        val sourceName = schema.findColumnName(field.sourceId()) ?: field.sourceId().toString()
+        val sourceName = icebergSchema.findColumnName(field.sourceId()) ?: field.sourceId().toString()
         if (field.transform().isIdentity) {
             sourceName
         } else {
@@ -180,9 +180,9 @@ private fun partitionSpecString(
 private fun loadIcebergTable(
     spark: SparkSession,
     catalog: String,
-    schema: String,
+    schemaName: String,
     tableName: String,
-): Table = Spark3Util.loadIcebergTable(spark, quotedFullName(catalog, schema, tableName))
+): Table = Spark3Util.loadIcebergTable(spark, quotedFullName(catalog, schemaName, tableName))
 
 private fun quotedFullName(vararg parts: String): String =
     parts.joinToString(".") { part -> "`${part.replace("`", "``")}`" }

--- a/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReader.kt
+++ b/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReader.kt
@@ -124,18 +124,16 @@ class IcebergMetadataReader {
         firstSnapshot: Snapshot,
         totalKey: String,
         addedKey: String,
-    ): Long? {
+    ): Long {
+        // Matches the legacy `$table.snapshots` SQL aggregation, which COALESCEd missing
+        // summary values to 0: baseline is the earliest retained snapshot's total, plus
+        // added deltas from every later snapshot. Iceberg omits `added-*` keys for
+        // snapshots that add no files (e.g. delete-only commits), so missing means 0.
         val firstSummary = firstSnapshot.summary().orEmpty()
-        val firstTotal = firstSummary.longValue(totalKey) ?: return null
-        val firstAdded = firstSummary.longValue(addedKey) ?: return null
-        val addedValues = snapshots.map { it.summary().orEmpty().longValue(addedKey) }
-
-        if (addedValues.any { it == null }) return null
-
-        // Iceberg summaries expose a current total and per-snapshot added counts. Use the
-        // first available total as the baseline, then add later snapshot deltas only when
-        // every needed summary value exists; otherwise return null instead of guessing.
-        return firstTotal + (addedValues.filterNotNull().sum() - firstAdded)
+        val firstTotal = firstSummary.longValue(totalKey) ?: 0L
+        val firstAdded = firstSummary.longValue(addedKey) ?: 0L
+        val addedSum = snapshots.sumOf { it.summary().orEmpty().longValue(addedKey) ?: 0L }
+        return firstTotal + (addedSum - firstAdded)
     }
 
     private fun Map<String, String>.longValue(key: String): Long? = this[key]?.toLongOrNull()

--- a/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/MetadataScraper.kt
+++ b/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/MetadataScraper.kt
@@ -169,8 +169,14 @@ class MetadataScraper(
                 .map { t ->
                     try {
                         tableMetadataExtractor
-                            .scrapeTable(spark, catalog.name, schema, t.name, t.isTemp)
-                            .also { it.log() }
+                            .scrapeTable(
+                                spark = spark,
+                                catalog = catalog.name,
+                                schema = schema,
+                                tableName = t.name,
+                                isTemp = t.isTemp,
+                                useIcebergFastPath = catalog.isIcebergCatalog() && !t.isView,
+                            ).also { it.log() }
                     } catch (_: ExcludedItemException) {
                         null // skipped
                     } catch (th: Throwable) {
@@ -194,4 +200,7 @@ class MetadataScraper(
             tableMetadataList = tables,
         )
     }
+
+    private fun CatalogDetails.isIcebergCatalog(): Boolean =
+        type.any { it.equals("iceberg", ignoreCase = true) }
 }

--- a/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/SparkMetadataReader.kt
+++ b/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/SparkMetadataReader.kt
@@ -81,12 +81,14 @@ class SparkMetadataReader {
         catalog: CatalogDetails,
         schema: String,
     ): List<ShowTablesRow> {
-        val rows = fetchTables(spark, catalog.name, schema) + fetchViews(spark, catalog, schema)
-        return rows
-            .distinctBy { it.getString(1) }
-            .map {
-                ShowTablesRow(name = it.getString(1), isTemp = it.getBoolean(2))
-            }
+        val tables =
+            fetchTables(spark, catalog.name, schema)
+                .map { ShowTablesRow(name = it.getString(1), isTemp = it.getBoolean(2), isView = false) }
+        val views =
+            fetchViews(spark, catalog, schema)
+                .map { ShowTablesRow(name = it.getString(1), isTemp = it.getBoolean(2), isView = true) }
+
+        return (views + tables).distinctBy { it.name }
     }
 
     private fun fetchTables(
@@ -217,6 +219,7 @@ class SparkMetadataReader {
 data class ShowTablesRow(
     val name: String,
     val isTemp: Boolean,
+    val isView: Boolean = false,
 )
 
 data class TableDescription(

--- a/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/TableMetadataExtractor.kt
+++ b/iomete-catalog-sync/src/main/kotlin/com/iomete/catalogsync/metadata/TableMetadataExtractor.kt
@@ -25,6 +25,7 @@ class TableMetadataExtractor(
     private val piiDetectionService: PIIDetectionService,
     private val applicationConfig: ApplicationConfig,
     private val sparkMetadataReader: SparkMetadataReader,
+    private val icebergMetadataReader: IcebergMetadataReader,
 ) {
     private val exclusionRules = applicationConfig.exclusionRules
 
@@ -34,10 +35,17 @@ class TableMetadataExtractor(
         schema: String,
         tableName: String,
         isTemp: Boolean,
+        useIcebergFastPath: Boolean = false,
     ): TableMetadata {
-        val table = sparkMetadataReader.describeTable(spark, catalog, schema, tableName)
+        val icebergMetadata =
+            if (useIcebergFastPath) {
+                loadIcebergMetadataSafe(spark, catalog, schema, tableName)
+            } else {
+                null
+            }
+        val table = icebergMetadata?.tableDescription ?: sparkMetadataReader.describeTable(spark, catalog, schema, tableName)
 
-        val tableProperties = parseIcebergPropertiesSafe(table.metadata["Table Properties"])
+        val tableProperties = icebergMetadata?.tableProperties ?: parseIcebergPropertiesSafe(table.metadata["Table Properties"])
 
         exclusionRules.enforceTableExclusionRules(
             table = tableName,
@@ -64,9 +72,13 @@ class TableMetadataExtractor(
             )
 
         val datasetStatistics: TableStatistics? =
-            when (tableExtractor) {
-                is SupportTableStatistics -> tableExtractor.extractTableStatistics()
-                else -> null
+            if (icebergMetadata != null) {
+                icebergMetadata.statistics
+            } else {
+                when (tableExtractor) {
+                    is SupportTableStatistics -> tableExtractor.extractTableStatistics()
+                    else -> null
+                }
             }
 
         val columnMetadataList: List<ColumnMetadata> = table.columns
@@ -146,6 +158,25 @@ class TableMetadataExtractor(
             sparkApplicationId = spark.sparkContext().applicationId(),
         )
     }
+
+    private fun loadIcebergMetadataSafe(
+        spark: SparkSession,
+        catalog: String,
+        schema: String,
+        tableName: String,
+    ): IcebergLoadedTableMetadata? =
+        try {
+            icebergMetadataReader.loadTableMetadata(spark, catalog, schema, tableName)
+        } catch (th: Throwable) {
+            logger.warn(
+                "Iceberg metadata fast path failed for {}.{}.{}, falling back to Spark DESCRIBE EXTENDED",
+                catalog,
+                schema,
+                tableName,
+                th,
+            )
+            null
+        }
 
     private fun parseIcebergPropertiesSafe(input: String?): Map<String, String> {
         if (input.isNullOrBlank()) return emptyMap()

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/integration/CatalogSyncIntegrationTest.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/integration/CatalogSyncIntegrationTest.kt
@@ -8,13 +8,16 @@ import com.iomete.catalogsync.config.ApplicationConfig
 import com.iomete.catalogsync.extract.TableExtractorFactory
 import com.iomete.catalogsync.extract.datasets.IcebergTableExtractor
 import com.iomete.catalogsync.metadata.CatalogMetadata
+import com.iomete.catalogsync.metadata.IcebergMetadataReader
 import com.iomete.catalogsync.metadata.MetadataScraper
 import com.iomete.catalogsync.metadata.SchemaMetadata
 import com.iomete.catalogsync.metadata.SparkMetadataReader
 import com.iomete.catalogsync.metadata.TableMetadata
 import com.iomete.catalogsync.metadata.TableMetadataExtractor
+import com.iomete.catalogsync.presidio.EntityType
 import com.iomete.catalogsync.presidio.PIIDetectionService
 import com.iomete.catalogsync.presidio.PresidioClient
+import com.iomete.catalogsync.presidio.PresidioResponse
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -59,6 +62,7 @@ class CatalogSyncIntegrationTest {
             piiDetectionService = piiDetectionService,
             applicationConfig = applicationConfig,
             sparkMetadataReader = sparkMetadataReader,
+            icebergMetadataReader = IcebergMetadataReader(),
         )
     }
 
@@ -162,6 +166,7 @@ class CatalogSyncIntegrationTest {
             schema = "test_db",
             tableName = "users",
             isTemp = false,
+            useIcebergFastPath = true,
         )
 
         assertEquals("test_catalog", metadata.catalog)
@@ -170,7 +175,10 @@ class CatalogSyncIntegrationTest {
         assertEquals("iceberg", metadata.provider)
         assertFalse(metadata.isView)
         assertFalse(metadata.isTemporary)
+        assertEquals("Users table comment", metadata.description)
         assertEquals(7, metadata.columns.size)
+        assertEquals("user id", metadata.columns.single { it.name == "id" }.description)
+        assertEquals("email address", metadata.columns.single { it.name == "email" }.description)
 
         // Stats should be present from real Iceberg snapshots
         assertNotNull(metadata.totalRecords, "totalRecords should be present")
@@ -188,6 +196,7 @@ class CatalogSyncIntegrationTest {
             schema = "test_db",
             tableName = "events",
             isTemp = false,
+            useIcebergFastPath = true,
         )
 
         val partitionCol = metadata.columns.find { it.name == "event_date" }
@@ -205,12 +214,88 @@ class CatalogSyncIntegrationTest {
             schema = "test_db",
             tableName = "empty_table",
             isTemp = false,
+            useIcebergFastPath = true,
         )
 
         assertEquals(2, metadata.columns.size, "empty_table should have 2 columns")
         assertNull(metadata.totalRecords, "empty_table should have null totalRecords")
         assertNull(metadata.sizeInBytes, "empty_table should have null sizeInBytes")
         assertNull(metadata.numFiles, "empty_table should have null numFiles")
+    }
+
+    @Test
+    fun `iceberg fast path preserves Spark path table metadata shape`() {
+        val sparkPath = tableMetadataExtractor.scrapeTable(
+            spark = spark,
+            catalog = "test_catalog",
+            schema = "test_db",
+            tableName = "users",
+            isTemp = false,
+            useIcebergFastPath = false,
+        )
+        val fastPath = tableMetadataExtractor.scrapeTable(
+            spark = spark,
+            catalog = "test_catalog",
+            schema = "test_db",
+            tableName = "users",
+            isTemp = false,
+            useIcebergFastPath = true,
+        )
+
+        assertEquals(sparkPath.catalog, fastPath.catalog)
+        assertEquals(sparkPath.schema, fastPath.schema)
+        assertEquals(sparkPath.name, fastPath.name)
+        assertEquals(sparkPath.tableType, fastPath.tableType)
+        assertEquals(sparkPath.provider, fastPath.provider)
+        assertEquals(sparkPath.isView, fastPath.isView)
+        assertEquals(sparkPath.columns.map { it.name }, fastPath.columns.map { it.name })
+        assertEquals(sparkPath.columns.map { it.dataType }, fastPath.columns.map { it.dataType })
+        assertEquals(sparkPath.columns.map { it.description }, fastPath.columns.map { it.description })
+        assertEquals(sparkPath.columns.map { it.sortOrder }, fastPath.columns.map { it.sortOrder })
+        assertEquals(sparkPath.columns.map { it.isPartitionKey }, fastPath.columns.map { it.isPartitionKey })
+        assertEquals(sparkPath.totalRecords, fastPath.totalRecords)
+        assertEquals(sparkPath.numFiles, fastPath.numFiles)
+        assertEquals(sparkPath.sizeInBytes, fastPath.sizeInBytes)
+        assertEquals(sparkPath.totalTableNumFiles, fastPath.totalTableNumFiles)
+        assertEquals(sparkPath.totalTableSizeInBytes, fastPath.totalTableSizeInBytes)
+    }
+
+    @Test
+    fun `iceberg fast path preserves PII tags`() {
+        System.setProperty("piiDetectionEnabled", "true")
+        try {
+            every { presidioClient.analyze(any()) } answers {
+                val text = firstArg<com.iomete.catalogsync.presidio.PresidioRequest>().text
+                if (text.contains("@")) {
+                    listOf(PresidioResponse(entityType = EntityType.EMAIL_ADDRESS, score = 0.95f))
+                } else {
+                    emptyList()
+                }
+            }
+            val piiEnabledExtractor = TableMetadataExtractor(
+                tableExtractorFactory = tableExtractorFactory,
+                piiDetectionService = PIIDetectionService(presidioClient),
+                applicationConfig = applicationConfig,
+                sparkMetadataReader = sparkMetadataReader,
+                icebergMetadataReader = IcebergMetadataReader(),
+            )
+
+            val metadata = piiEnabledExtractor.scrapeTable(
+                spark = spark,
+                catalog = "test_catalog",
+                schema = "test_db",
+                tableName = "users",
+                isTemp = false,
+                useIcebergFastPath = true,
+            )
+
+            val emailColumn = metadata.columns.single { it.name == "email" }
+            assertTrue(emailColumn.tags.contains("DETECTED:EMAIL_ADDRESS"))
+            assertTrue(emailColumn.tags.contains("DETECTED:PII"))
+            assertTrue(metadata.tags.contains("DETECTED:PII"))
+        } finally {
+            System.clearProperty("piiDetectionEnabled")
+        }
     }
 
     @Test
@@ -255,6 +340,21 @@ class CatalogSyncIntegrationTest {
             assertTrue(indexedTableNames.contains("test_db.events"))
             assertTrue(indexedTableNames.contains("test_db.empty_table"))
             assertTrue(indexedTableNames.contains("another_db.products"))
+
+            val indexedUsers = capturedTables.single { it.schema == "test_db" && it.name == "users" }
+            assertEquals("Users table comment", indexedUsers.description)
+            assertEquals(5L, indexedUsers.totalRecords)
+            assertTrue(indexedUsers.numFiles!! > 0)
+            assertTrue(indexedUsers.sizeInBytes!! > 0)
+            assertEquals("email address", indexedUsers.columns.single { it.name == "email" }.description)
+
+            val indexedEvents = capturedTables.single { it.schema == "test_db" && it.name == "events" }
+            assertTrue(indexedEvents.columns.single { it.name == "event_date" }.isPartitionKey)
+
+            val indexedEmptyTable = capturedTables.single { it.schema == "test_db" && it.name == "empty_table" }
+            assertNull(indexedEmptyTable.totalRecords)
+            assertNull(indexedEmptyTable.numFiles)
+            assertNull(indexedEmptyTable.sizeInBytes)
 
             // Verify 2 schemas were indexed
             assertEquals(2, capturedSchemas.size, "Should index 2 schemas")

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/integration/TestDataSetup.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/integration/TestDataSetup.kt
@@ -15,14 +15,26 @@ object TestDataSetup {
         spark.sql(
             """
             CREATE TABLE IF NOT EXISTS test_catalog.test_db.users (
-                id BIGINT,
-                name STRING,
+                id BIGINT COMMENT 'user id',
+                name STRING COMMENT 'full name',
                 age INT,
                 salary DOUBLE,
                 is_active BOOLEAN,
                 created_at TIMESTAMP,
-                email STRING
+                email STRING COMMENT 'email address'
             ) USING iceberg
+            TBLPROPERTIES (
+                'comment'='Users table comment',
+                'hidden'='false'
+            )
+            """.trimIndent()
+        )
+        spark.sql(
+            """
+            ALTER TABLE test_catalog.test_db.users SET TBLPROPERTIES (
+                'comment'='Users table comment',
+                'hidden'='false'
+            )
             """.trimIndent()
         )
         spark.sql(

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReaderTest.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReaderTest.kt
@@ -1,0 +1,375 @@
+package com.iomete.catalogsync.metadata
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.apache.iceberg.PartitionSpec
+import org.apache.iceberg.Schema
+import org.apache.iceberg.Snapshot
+import org.apache.iceberg.Table
+import org.apache.iceberg.types.Types
+import org.apache.spark.sql.SparkSession
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IcebergMetadataReaderTest {
+    private val spark = mockk<SparkSession>(relaxed = true)
+
+    @Test
+    fun `loads columns comments partition flags spec properties and summary metrics from iceberg table`() {
+        val schema = Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get(), "record id"),
+            Types.NestedField.optional(2, "region", Types.StringType.get(), "sales region"),
+            Types.NestedField.optional(3, "amount", Types.DecimalType.of(10, 2), "order amount"),
+        )
+        val partitionSpec = PartitionSpec.builderFor(schema).identity("region").build()
+        val firstSnapshot = snapshot(
+            timestampMillis = 1_700_000_000_000,
+            summary = mapOf(
+                "total-data-files" to "3",
+                "total-files-size" to "500",
+                "total-records" to "100",
+                "added-data-files" to "3",
+                "added-files-size" to "500",
+            ),
+        )
+        val currentSnapshot = snapshot(
+            timestampMillis = 1_700_000_500_000,
+            summary = mapOf(
+                "total-data-files" to "5",
+                "total-files-size" to "1024",
+                "total-records" to "250",
+                "added-data-files" to "7",
+                "added-files-size" to "900",
+            ),
+        )
+        val table = table(
+            schema = schema,
+            spec = partitionSpec,
+            properties = mapOf(
+                "comment" to "orders table",
+                "owner" to "analytics",
+                "hidden" to "true",
+            ),
+            currentSnapshot = currentSnapshot,
+            snapshots = listOf(currentSnapshot, firstSnapshot),
+        )
+
+        val metadata = readerReturning(table).loadTableMetadata(spark, "cat", "sales", "orders")
+
+        assertEquals(
+            mapOf("comment" to "orders table", "owner" to "analytics", "hidden" to "true"),
+            metadata.tableProperties,
+        )
+        assertEquals("MANAGED", metadata.tableDescription.metadata["Type"])
+        assertEquals("iceberg", metadata.tableDescription.metadata["Provider"])
+        assertEquals("orders table", metadata.tableDescription.metadata["Comment"])
+        assertEquals("analytics", metadata.tableDescription.metadata["Owner"])
+        assertEquals("region", metadata.tableDescription.metadata["Partition Spec"])
+        assertEquals(
+            "[comment=orders table, hidden=true, owner=analytics]",
+            metadata.tableDescription.metadata["Table Properties"],
+        )
+
+        val columns = metadata.tableDescription.columns
+        assertEquals(listOf("id", "region", "amount"), columns.map { it.name })
+        assertEquals(listOf("bigint", "string", "decimal(10,2)"), columns.map { it.dataType })
+        assertEquals(listOf("record id", "sales region", "order amount"), columns.map { it.description })
+        assertEquals(listOf(0, 1, 2), columns.map { it.sortOrder })
+        assertFalse(columns.single { it.name == "id" }.isPartitionKey)
+        assertTrue(columns.single { it.name == "region" }.isPartitionKey)
+        assertFalse(columns.single { it.name == "amount" }.isPartitionKey)
+
+        assertNotNull(metadata.statistics)
+        assertEquals(currentSnapshot.timestampMillis(), metadata.statistics!!.lastModified)
+        assertEquals(5L, metadata.statistics.numFiles)
+        assertEquals(10L, metadata.statistics.totalTableNumFiles)
+        assertEquals(1024L, metadata.statistics.sizeInBytes)
+        assertEquals(1400L, metadata.statistics.totalTableSizeInBytes)
+        assertEquals(250L, metadata.statistics.totalRecords)
+    }
+
+    @Test
+    fun `formats primitive and nested iceberg types using spark compatible type strings`() {
+        val schema = Schema(
+            Types.NestedField.required(1, "bool_col", Types.BooleanType.get()),
+            Types.NestedField.required(2, "int_col", Types.IntegerType.get()),
+            Types.NestedField.required(3, "long_col", Types.LongType.get()),
+            Types.NestedField.required(4, "float_col", Types.FloatType.get()),
+            Types.NestedField.required(5, "double_col", Types.DoubleType.get()),
+            Types.NestedField.required(6, "date_col", Types.DateType.get()),
+            Types.NestedField.required(7, "ts_col", Types.TimestampType.withoutZone()),
+            Types.NestedField.required(8, "ts_with_zone_col", Types.TimestampType.withZone()),
+            Types.NestedField.required(9, "string_col", Types.StringType.get()),
+            Types.NestedField.required(10, "binary_col", Types.BinaryType.get()),
+            Types.NestedField.required(11, "decimal_col", Types.DecimalType.of(12, 4)),
+            Types.NestedField.required(12, "list_col", Types.ListType.ofOptional(13, Types.StringType.get())),
+            Types.NestedField.required(
+                14,
+                "map_col",
+                Types.MapType.ofOptional(15, 16, Types.StringType.get(), Types.LongType.get()),
+            ),
+            Types.NestedField.required(
+                17,
+                "struct_col",
+                Types.StructType.of(
+                    Types.NestedField.required(18, "nested_id", Types.IntegerType.get()),
+                    Types.NestedField.optional(19, "nested_name", Types.StringType.get()),
+                ),
+            ),
+        )
+        val table = table(
+            schema = schema,
+            spec = PartitionSpec.unpartitioned(),
+            currentSnapshot = null,
+            snapshots = emptyList(),
+        )
+
+        val columns = readerReturning(table).loadTableMetadata(spark, "cat", "sch", "tbl").tableDescription.columns
+
+        assertEquals(
+            listOf(
+                "boolean",
+                "int",
+                "bigint",
+                "float",
+                "double",
+                "date",
+                "timestamp_ntz",
+                "timestamp",
+                "string",
+                "binary",
+                "decimal(12,4)",
+                "array<string>",
+                "map<string,bigint>",
+                "struct<nested_id:int,nested_name:string>",
+            ),
+            columns.map { it.dataType },
+        )
+    }
+
+    @Test
+    fun `throws for unsupported iceberg time type`() {
+        val schema = Schema(
+            Types.NestedField.required(1, "time_col", Types.TimeType.get()),
+        )
+        val table = table(
+            schema = schema,
+            spec = PartitionSpec.unpartitioned(),
+            currentSnapshot = null,
+            snapshots = emptyList(),
+        )
+
+        val exception = assertThrows(UnsupportedOperationException::class.java) {
+            readerReturning(table).loadTableMetadata(spark, "cat", "sch", "tbl")
+        }
+
+        assertEquals("Spark does not support Iceberg time fields", exception.message)
+    }
+
+    @Test
+    fun `returns null statistics for table with no current snapshot`() {
+        val schema = Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()))
+        val table = table(
+            schema = schema,
+            spec = PartitionSpec.unpartitioned(),
+            currentSnapshot = null,
+            snapshots = emptyList(),
+        )
+
+        val metadata = readerReturning(table).loadTableMetadata(spark, "cat", "sch", "empty_table")
+
+        assertNull(metadata.statistics)
+        assertEquals(listOf("id"), metadata.tableDescription.columns.map { it.name })
+        assertEquals("[]", metadata.tableDescription.metadata["Partition Spec"])
+    }
+
+    @Test
+    fun `handles missing summary values without failing`() {
+        val schema = Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()))
+        val firstSnapshot = snapshot(
+            timestampMillis = 10,
+            summary = mapOf("total-data-files" to "2", "added-data-files" to "2"),
+        )
+        val currentSnapshot = snapshot(
+            timestampMillis = 20,
+            summary = mapOf("total-data-files" to "4", "added-data-files" to "2"),
+        )
+        val table = table(
+            schema = schema,
+            spec = PartitionSpec.unpartitioned(),
+            currentSnapshot = currentSnapshot,
+            snapshots = listOf(firstSnapshot, currentSnapshot),
+        )
+
+        val stats = readerReturning(table).loadTableMetadata(spark, "cat", "sch", "tbl").statistics
+
+        assertNotNull(stats)
+        assertEquals(4L, stats!!.numFiles)
+        assertEquals(4L, stats.totalTableNumFiles)
+        assertNull(stats.sizeInBytes)
+        assertNull(stats.totalTableSizeInBytes)
+        assertNull(stats.totalRecords)
+    }
+
+    @Test
+    fun `returns null historical totals instead of drifting when added summary values are missing`() {
+        val schema = Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()))
+        val firstSnapshot = snapshot(
+            timestampMillis = 10,
+            summary = mapOf(
+                "total-data-files" to "2",
+                "total-files-size" to "100",
+                "added-data-files" to "2",
+                "added-files-size" to "100",
+            ),
+        )
+        val currentSnapshot = snapshot(
+            timestampMillis = 20,
+            summary = mapOf(
+                "total-data-files" to "4",
+                "total-files-size" to "250",
+                "added-files-size" to "150",
+            ),
+        )
+        val table = table(
+            schema = schema,
+            spec = PartitionSpec.unpartitioned(),
+            currentSnapshot = currentSnapshot,
+            snapshots = listOf(firstSnapshot, currentSnapshot),
+        )
+
+        val stats = readerReturning(table).loadTableMetadata(spark, "cat", "sch", "tbl").statistics
+
+        assertNotNull(stats)
+        assertEquals(4L, stats!!.numFiles)
+        assertNull(stats.totalTableNumFiles)
+        assertEquals(250L, stats.sizeInBytes)
+        assertEquals(250L, stats.totalTableSizeInBytes)
+    }
+
+    @Test
+    fun `computes historical totals from available retained snapshot summaries`() {
+        val schema = Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()))
+        val retainedFirstSnapshot = snapshot(
+            timestampMillis = 10,
+            summary = mapOf(
+                "total-data-files" to "100",
+                "total-files-size" to "1000",
+                "added-data-files" to "25",
+                "added-files-size" to "250",
+            ),
+        )
+        val currentSnapshot = snapshot(
+            timestampMillis = 20,
+            summary = mapOf(
+                "total-data-files" to "90",
+                "total-files-size" to "950",
+                "added-data-files" to "10",
+                "added-files-size" to "100",
+            ),
+        )
+        val table = table(
+            schema = schema,
+            spec = PartitionSpec.unpartitioned(),
+            currentSnapshot = currentSnapshot,
+            snapshots = listOf(retainedFirstSnapshot, currentSnapshot),
+        )
+
+        val stats = readerReturning(table).loadTableMetadata(spark, "cat", "sch", "tbl").statistics
+
+        assertNotNull(stats)
+        assertEquals(90L, stats!!.numFiles)
+        assertEquals(110L, stats.totalTableNumFiles)
+        assertEquals(950L, stats.sizeInBytes)
+        assertEquals(1100L, stats.totalTableSizeInBytes)
+    }
+
+    @Test
+    fun `marks transformed partition source columns as partition keys and exposes transform spec`() {
+        val schema = Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "event_time", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(3, "payload", Types.StringType.get()),
+        )
+        val spec =
+            PartitionSpec
+                .builderFor(schema)
+                .bucket("id", 16)
+                .day("event_time")
+                .build()
+        val table = table(
+            schema = schema,
+            spec = spec,
+            currentSnapshot = null,
+            snapshots = emptyList(),
+        )
+
+        val metadata = readerReturning(table).loadTableMetadata(spark, "cat", "sch", "tbl")
+        val columns = metadata.tableDescription.columns
+
+        assertEquals("bucket[16](id), day(event_time)", metadata.tableDescription.metadata["Partition Spec"])
+        assertTrue(columns.single { it.name == "id" }.isPartitionKey)
+        assertTrue(columns.single { it.name == "event_time" }.isPartitionKey)
+        assertFalse(columns.single { it.name == "payload" }.isPartitionKey)
+    }
+
+    @Test
+    fun `uses snapshot summaries only and does not read manifests`() {
+        val schema = Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()))
+        val currentSnapshot = snapshot(
+            timestampMillis = 20,
+            summary = mapOf(
+                "total-data-files" to "1",
+                "total-files-size" to "100",
+                "total-records" to "10",
+                "added-data-files" to "1",
+                "added-files-size" to "100",
+            ),
+        )
+        val table = table(
+            schema = schema,
+            spec = PartitionSpec.unpartitioned(),
+            currentSnapshot = currentSnapshot,
+            snapshots = listOf(currentSnapshot),
+        )
+
+        readerReturning(table).loadTableMetadata(spark, "cat", "sch", "tbl")
+
+        verify(exactly = 0) { table.io() }
+        verify(exactly = 0) { currentSnapshot.allManifests(any()) }
+    }
+
+    private fun readerReturning(table: Table) = IcebergMetadataReader { _, _, _, _ -> table }
+
+    private fun table(
+        schema: Schema,
+        spec: PartitionSpec,
+        properties: Map<String, String> = emptyMap(),
+        currentSnapshot: Snapshot?,
+        snapshots: List<Snapshot>,
+    ): Table {
+        val table = mockk<Table>(relaxed = true)
+        every { table.schema() } returns schema
+        every { table.spec() } returns spec
+        every { table.properties() } returns properties
+        every { table.currentSnapshot() } returns currentSnapshot
+        every { table.snapshots() } returns snapshots
+        return table
+    }
+
+    private fun snapshot(
+        timestampMillis: Long,
+        summary: Map<String, String>,
+    ): Snapshot {
+        val snapshot = mockk<Snapshot>(relaxed = true)
+        every { snapshot.timestampMillis() } returns timestampMillis
+        every { snapshot.summary() } returns summary
+        return snapshot
+    }
+}

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReaderTest.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReaderTest.kt
@@ -66,7 +66,7 @@ class IcebergMetadataReaderTest {
             mapOf("comment" to "orders table", "owner" to "analytics", "hidden" to "true"),
             metadata.tableProperties,
         )
-        assertEquals("MANAGED", metadata.tableDescription.metadata["Type"])
+        assertFalse(metadata.tableDescription.metadata.containsKey("Type"))
         assertEquals("iceberg", metadata.tableDescription.metadata["Provider"])
         assertEquals("orders table", metadata.tableDescription.metadata["Comment"])
         assertEquals("analytics", metadata.tableDescription.metadata["Owner"])

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReaderTest.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/IcebergMetadataReaderTest.kt
@@ -213,12 +213,14 @@ class IcebergMetadataReaderTest {
         assertEquals(4L, stats!!.numFiles)
         assertEquals(4L, stats.totalTableNumFiles)
         assertNull(stats.sizeInBytes)
-        assertNull(stats.totalTableSizeInBytes)
+        // Legacy `$table.snapshots` SQL coalesced missing summary values to 0, so a table
+        // whose snapshots never report size sums to 0, not null.
+        assertEquals(0L, stats.totalTableSizeInBytes)
         assertNull(stats.totalRecords)
     }
 
     @Test
-    fun `returns null historical totals instead of drifting when added summary values are missing`() {
+    fun `treats missing added summary values as zero like the legacy snapshots sql path`() {
         val schema = Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()))
         val firstSnapshot = snapshot(
             timestampMillis = 10,
@@ -248,9 +250,60 @@ class IcebergMetadataReaderTest {
 
         assertNotNull(stats)
         assertEquals(4L, stats!!.numFiles)
-        assertNull(stats.totalTableNumFiles)
+        // Current snapshot omits added-data-files (added no files): counts as 0.
+        assertEquals(2L, stats.totalTableNumFiles)
         assertEquals(250L, stats.sizeInBytes)
         assertEquals(250L, stats.totalTableSizeInBytes)
+    }
+
+    @Test
+    fun `computes historical totals when history contains delete-only snapshots without added keys`() {
+        val schema = Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()))
+        val firstSnapshot = snapshot(
+            timestampMillis = 10,
+            summary = mapOf(
+                "total-data-files" to "4",
+                "total-files-size" to "400",
+                "added-data-files" to "4",
+                "added-files-size" to "400",
+            ),
+        )
+        // Delete-only commit: Iceberg omits added-* keys entirely.
+        val deleteSnapshot = snapshot(
+            timestampMillis = 15,
+            summary = mapOf(
+                "total-data-files" to "2",
+                "total-files-size" to "200",
+                "total-records" to "20",
+            ),
+        )
+        val currentSnapshot = snapshot(
+            timestampMillis = 20,
+            summary = mapOf(
+                "total-data-files" to "5",
+                "total-files-size" to "500",
+                "total-records" to "50",
+                "added-data-files" to "3",
+                "added-files-size" to "300",
+            ),
+        )
+        val table = table(
+            schema = schema,
+            spec = PartitionSpec.unpartitioned(),
+            currentSnapshot = currentSnapshot,
+            snapshots = listOf(firstSnapshot, deleteSnapshot, currentSnapshot),
+        )
+
+        val stats = readerReturning(table).loadTableMetadata(spark, "cat", "sch", "tbl").statistics
+
+        assertNotNull(stats)
+        assertEquals(5L, stats!!.numFiles)
+        assertEquals(500L, stats.sizeInBytes)
+        assertEquals(50L, stats.totalRecords)
+        // 4 (first total) + (4 + 0 + 3 added) - 4 (first added) = 7
+        assertEquals(7L, stats.totalTableNumFiles)
+        // 400 + (400 + 0 + 300) - 400 = 700
+        assertEquals(700L, stats.totalTableSizeInBytes)
     }
 
     @Test

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/MetadataScraperTest.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/MetadataScraperTest.kt
@@ -91,6 +91,70 @@ class MetadataScraperTest {
     }
 
     @Test
+    fun `run enables iceberg fast path only for non-view tables in iceberg catalogs`() {
+        val table = makeTableMetadata("test_catalog", "schema1", "table1")
+        val view = makeTableMetadata("test_catalog", "schema1", "view1").copy(tableType = "view", isView = true)
+
+        every { mockCoreServiceClient.catalogs() } returns listOf(testCatalog)
+        every { mockSparkMetadataReader.getSchemas(mockSparkSession, "test_catalog") } returns listOf("schema1")
+        every { mockSparkMetadataReader.getSchemaProperties(mockSparkSession, "test_catalog", "schema1") } returns emptyMap()
+        every {
+            mockSparkMetadataReader.getTables(mockSparkSession, match { it.name == "test_catalog" }, "schema1")
+        } returns listOf(
+            ShowTablesRow(name = "table1", isTemp = false, isView = false),
+            ShowTablesRow(name = "view1", isTemp = false, isView = true),
+        )
+        every {
+            mockTableMetadataExtractor.scrapeTable(
+                spark = mockSparkSession,
+                catalog = "test_catalog",
+                schema = "schema1",
+                tableName = "table1",
+                isTemp = false,
+                useIcebergFastPath = true,
+            )
+        } returns table
+        every {
+            mockTableMetadataExtractor.scrapeTable(
+                spark = mockSparkSession,
+                catalog = "test_catalog",
+                schema = "schema1",
+                tableName = "view1",
+                isTemp = false,
+                useIcebergFastPath = false,
+            )
+        } returns view
+
+        val mockResponse = mockk<Response>()
+        every { mockCatalogServiceClient.indexTable(any()) } returns mockResponse
+        every { mockCatalogServiceClient.indexSchema(any()) } returns mockResponse
+        every { mockCatalogServiceClient.indexCatalog(any()) } returns mockResponse
+
+        scraper.run()
+
+        verify(exactly = 1) {
+            mockTableMetadataExtractor.scrapeTable(
+                spark = mockSparkSession,
+                catalog = "test_catalog",
+                schema = "schema1",
+                tableName = "table1",
+                isTemp = false,
+                useIcebergFastPath = true,
+            )
+        }
+        verify(exactly = 1) {
+            mockTableMetadataExtractor.scrapeTable(
+                spark = mockSparkSession,
+                catalog = "test_catalog",
+                schema = "schema1",
+                tableName = "view1",
+                isTemp = false,
+                useIcebergFastPath = false,
+            )
+        }
+    }
+
+    @Test
     fun `run skips excluded catalogs`() {
         val excludedCatalog = CatalogDetails(
             name = "excluded_catalog",
@@ -287,7 +351,14 @@ class MetadataScraperTest {
 
         tableMetadataList.forEach { tm ->
             every {
-                mockTableMetadataExtractor.scrapeTable(mockSparkSession, catalogName, schemaName, tm.name, false)
+                mockTableMetadataExtractor.scrapeTable(
+                    spark = mockSparkSession,
+                    catalog = catalogName,
+                    schema = schemaName,
+                    tableName = tm.name,
+                    isTemp = false,
+                    useIcebergFastPath = any(),
+                )
             } returns tm
         }
     }

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/SparkMetadataReaderTest.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/SparkMetadataReaderTest.kt
@@ -67,6 +67,26 @@ class SparkMetadataReaderTest {
     }
 
     @Test
+    fun `getTables marks views from show views`() {
+        val mockViewRow = mockk<Row>()
+        every { mockViewRow.getString(1) } returns "view1"
+        every { mockViewRow.getBoolean(2) } returns false
+
+        val tablesDataset = mockk<Dataset<Row>>()
+        val viewsDataset = mockk<Dataset<Row>>()
+
+        every { mockSparkSession.sql("show tables from `catalog1`.`schema1`") } returns tablesDataset
+        every { mockSparkSession.sql("show views from `catalog1`.`schema1`") } returns viewsDataset
+        every { tablesDataset.collectAsList() } returns emptyList()
+        every { viewsDataset.collectAsList() } returns listOf(mockViewRow)
+
+        val catalog = CoreClient.CatalogDetails(name = "catalog1", type = listOf("iceberg"))
+        val result = reader.getTables(mockSparkSession, catalog, "schema1")
+
+        assertEquals(listOf(ShowTablesRow(name = "view1", isTemp = false, isView = true)), result)
+    }
+
+    @Test
     fun `getTables should work when tables fail but views succeed`() {
         val mockViewRow = mockk<Row>()
         every { mockViewRow.getString(1) } returns "view1"

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/TableMetadataExtractorTest.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/TableMetadataExtractorTest.kt
@@ -27,6 +27,7 @@ class TableMetadataExtractorTest {
     private lateinit var piiDetectionService: PIIDetectionService
     private lateinit var applicationConfig: ApplicationConfig
     private lateinit var sparkMetadataReader: SparkMetadataReader
+    private lateinit var icebergMetadataReader: IcebergMetadataReader
     private lateinit var tableMetadataExtractor: TableMetadataExtractor
     private lateinit var sparkSession: SparkSession
 
@@ -36,6 +37,7 @@ class TableMetadataExtractorTest {
         piiDetectionService = mockk()
         applicationConfig = mockk()
         sparkMetadataReader = mockk()
+        icebergMetadataReader = mockk()
         sparkSession = mockk(relaxed = true)
 
         every { applicationConfig.exclusionRules } returns ExclusionRules(
@@ -52,6 +54,7 @@ class TableMetadataExtractorTest {
                 piiDetectionService,
                 applicationConfig,
                 sparkMetadataReader,
+                icebergMetadataReader,
             )
     }
 
@@ -85,7 +88,7 @@ class TableMetadataExtractorTest {
 
     private fun extractorWithExclusionRules(exclusionRules: ExclusionRules): TableMetadataExtractor {
         every { applicationConfig.exclusionRules } returns exclusionRules
-        return TableMetadataExtractor(tableExtractorFactory, piiDetectionService, applicationConfig, sparkMetadataReader)
+        return TableMetadataExtractor(tableExtractorFactory, piiDetectionService, applicationConfig, sparkMetadataReader, icebergMetadataReader)
     }
 
     @Test
@@ -397,6 +400,259 @@ class TableMetadataExtractorTest {
         val result = tableMetadataExtractor.scrapeTable(sparkSession, "test_catalog", "test_schema", "test_table", false)
 
         assertNull(result.createdAt)
+    }
+
+    @Test
+    fun `scrapeTable uses iceberg fast path without Spark describe or snapshot statistics query`() {
+        val fastPathStats = TableStatistics(
+            lastModified = 1000L,
+            numFiles = 5L,
+            totalTableNumFiles = 10L,
+            sizeInBytes = 1024L,
+            totalTableSizeInBytes = 2048L,
+            totalRecords = 100L,
+        )
+        val fastPathMetadata = IcebergLoadedTableMetadata(
+            tableDescription = TableDescription(
+                columns = listOf(ColumnMetadata("id", "int", null, 0, false)),
+                metadata = mapOf("Type" to "MANAGED", "Provider" to "iceberg", "Comment" to "from iceberg"),
+            ),
+            tableProperties = mapOf("hidden" to "false"),
+            statistics = fastPathStats,
+        )
+        val statsExtractor = object : TableExtractor, SupportTableStatistics {
+            override val getTableType = "MANAGED"
+            override fun extractTableStatistics(): TableStatistics = error("should not query Iceberg snapshots on fast path")
+        }
+
+        every {
+            icebergMetadataReader.loadTableMetadata(sparkSession, "cat", "sch", "tbl")
+        } returns fastPathMetadata
+        every {
+            tableExtractorFactory.extractorFor(
+                spark = sparkSession,
+                provider = "iceberg",
+                isView = false,
+                catalog = "cat",
+                schema = "sch",
+                table = "tbl",
+                tableProperties = mapOf("hidden" to "false"),
+            )
+        } returns statsExtractor
+
+        val result = tableMetadataExtractor.scrapeTable(
+            spark = sparkSession,
+            catalog = "cat",
+            schema = "sch",
+            tableName = "tbl",
+            isTemp = false,
+            useIcebergFastPath = true,
+        )
+
+        assertEquals("from iceberg", result.description)
+        assertEquals(fastPathStats.lastModified, result.lastModified)
+        assertEquals(fastPathStats.numFiles, result.numFiles)
+        assertEquals(fastPathStats.totalTableNumFiles, result.totalTableNumFiles)
+        verify(exactly = 0) { sparkMetadataReader.describeTable(any(), any(), any(), any()) }
+        verify(exactly = 0) { sparkSession.sql(match { it.contains("snapshots", ignoreCase = true) }) }
+    }
+
+    @Test
+    fun `scrapeTable fast path preserves complete output shape in regular test gate`() {
+        val columns = listOf(
+            ColumnMetadata("id", "bigint", "user id", 0, false),
+            ColumnMetadata("email", "string", "email address", 1, false),
+            ColumnMetadata("event_date", "string", "event partition date", 2, true),
+        )
+        val fastPathStats = TableStatistics(
+            lastModified = 1234L,
+            numFiles = 2L,
+            totalTableNumFiles = 3L,
+            sizeInBytes = 512L,
+            totalTableSizeInBytes = 768L,
+            totalRecords = 5L,
+        )
+        val fastPathMetadata = IcebergLoadedTableMetadata(
+            tableDescription = TableDescription(
+                columns = columns,
+                metadata = mapOf(
+                    "Type" to "MANAGED",
+                    "Provider" to "iceberg",
+                    "Comment" to "users table",
+                    "Owner" to "analytics",
+                    "Partition Spec" to "event_date",
+                ),
+            ),
+            tableProperties = mapOf("comment" to "users table", "owner" to "analytics", "hidden" to "false"),
+            statistics = fastPathStats,
+        )
+        val tagsExtractor = object : TableExtractor, SupportColumnTags {
+            override val getTableType = "MANAGED"
+        }
+
+        every {
+            icebergMetadataReader.loadTableMetadata(sparkSession, "cat", "sch", "tbl")
+        } returns fastPathMetadata
+        every {
+            tableExtractorFactory.extractorFor(
+                spark = sparkSession,
+                provider = "iceberg",
+                isView = false,
+                catalog = "cat",
+                schema = "sch",
+                table = "tbl",
+                tableProperties = mapOf("comment" to "users table", "owner" to "analytics", "hidden" to "false"),
+            )
+        } returns tagsExtractor
+        every {
+            piiDetectionService.extract(
+                spark = sparkSession,
+                catalog = "cat",
+                fullTableName = "`cat`.`sch`.`tbl`",
+                columns = listOf("id", "email", "event_date"),
+            )
+        } returns mapOf("email" to listOf("DETECTED:EMAIL_ADDRESS", "DETECTED:PII"))
+
+        val result = tableMetadataExtractor.scrapeTable(
+            spark = sparkSession,
+            catalog = "cat",
+            schema = "sch",
+            tableName = "tbl",
+            isTemp = false,
+            useIcebergFastPath = true,
+        )
+
+        assertEquals("cat", result.catalog)
+        assertEquals("sch", result.schema)
+        assertEquals("tbl", result.name)
+        assertEquals("MANAGED", result.tableType)
+        assertFalse(result.isView)
+        assertEquals("iceberg", result.provider)
+        assertEquals("users table", result.description)
+        assertEquals("analytics", result.owner)
+        assertEquals(fastPathStats.lastModified, result.lastModified)
+        assertEquals(fastPathStats.numFiles, result.numFiles)
+        assertEquals(fastPathStats.totalTableNumFiles, result.totalTableNumFiles)
+        assertEquals(fastPathStats.sizeInBytes, result.sizeInBytes)
+        assertEquals(fastPathStats.totalTableSizeInBytes, result.totalTableSizeInBytes)
+        assertEquals(fastPathStats.totalRecords, result.totalRecords)
+        assertEquals(listOf("id", "email", "event_date"), result.columns.map { it.name })
+        assertEquals(listOf("bigint", "string", "string"), result.columns.map { it.dataType })
+        assertEquals(listOf("user id", "email address", "event partition date"), result.columns.map { it.description })
+        assertEquals(listOf(0, 1, 2), result.columns.map { it.sortOrder })
+        assertEquals(listOf(false, false, true), result.columns.map { it.isPartitionKey })
+        assertEquals(listOf("DETECTED:EMAIL_ADDRESS", "DETECTED:PII"), result.columns.single { it.name == "email" }.tags)
+        assertEquals(listOf("DETECTED:PII"), result.tags)
+        verify(exactly = 0) { sparkMetadataReader.describeTable(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `scrapeTable fast path preserves empty table statistics in regular test gate`() {
+        val fastPathMetadata = IcebergLoadedTableMetadata(
+            tableDescription = TableDescription(
+                columns = listOf(
+                    ColumnMetadata("id", "bigint", null, 0, false),
+                    ColumnMetadata("value", "string", null, 1, false),
+                ),
+                metadata = mapOf("Type" to "MANAGED", "Provider" to "iceberg"),
+            ),
+            tableProperties = emptyMap(),
+            statistics = null,
+        )
+        val extractor = mockk<TableExtractor>()
+
+        every {
+            icebergMetadataReader.loadTableMetadata(sparkSession, "cat", "sch", "empty_table")
+        } returns fastPathMetadata
+        every {
+            tableExtractorFactory.extractorFor(
+                spark = sparkSession,
+                provider = "iceberg",
+                isView = false,
+                catalog = "cat",
+                schema = "sch",
+                table = "empty_table",
+                tableProperties = emptyMap(),
+            )
+        } returns extractor
+
+        val result = tableMetadataExtractor.scrapeTable(
+            spark = sparkSession,
+            catalog = "cat",
+            schema = "sch",
+            tableName = "empty_table",
+            isTemp = false,
+            useIcebergFastPath = true,
+        )
+
+        assertEquals(listOf("id", "value"), result.columns.map { it.name })
+        assertNull(result.lastModified)
+        assertNull(result.numFiles)
+        assertNull(result.totalTableNumFiles)
+        assertNull(result.sizeInBytes)
+        assertNull(result.totalTableSizeInBytes)
+        assertNull(result.totalRecords)
+        verify(exactly = 0) { sparkMetadataReader.describeTable(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `scrapeTable falls back to Spark describe when iceberg fast path fails`() {
+        val fallbackStats = TableStatistics(lastModified = 2000L, numFiles = 2L)
+        val fallbackExtractor = object : TableExtractor, SupportTableStatistics {
+            override val getTableType = "MANAGED"
+            override fun extractTableStatistics() = fallbackStats
+        }
+        val fallbackDescription = TableDescription(
+            columns = listOf(ColumnMetadata("id", "int", null, 0, false)),
+            metadata = mapOf("Type" to "MANAGED", "Provider" to "iceberg", "Comment" to "from spark"),
+        )
+
+        every {
+            icebergMetadataReader.loadTableMetadata(sparkSession, "cat", "sch", "tbl")
+        } throws RuntimeException("boom")
+        every { sparkMetadataReader.describeTable(sparkSession, "cat", "sch", "tbl") } returns fallbackDescription
+        every {
+            tableExtractorFactory.extractorFor(
+                spark = sparkSession,
+                provider = "iceberg",
+                isView = false,
+                catalog = "cat",
+                schema = "sch",
+                table = "tbl",
+                tableProperties = emptyMap(),
+            )
+        } returns fallbackExtractor
+
+        val result = tableMetadataExtractor.scrapeTable(
+            spark = sparkSession,
+            catalog = "cat",
+            schema = "sch",
+            tableName = "tbl",
+            isTemp = false,
+            useIcebergFastPath = true,
+        )
+
+        assertEquals("from spark", result.description)
+        assertEquals(fallbackStats.lastModified, result.lastModified)
+        assertEquals(fallbackStats.numFiles, result.numFiles)
+        verify(exactly = 1) { sparkMetadataReader.describeTable(sparkSession, "cat", "sch", "tbl") }
+    }
+
+    @Test
+    fun `scrapeTable keeps Spark describe path when iceberg fast path is disabled`() {
+        setupBasicTableExtractor(metadata = mapOf("Type" to "MANAGED", "Provider" to "iceberg"))
+
+        tableMetadataExtractor.scrapeTable(
+            spark = sparkSession,
+            catalog = "test_catalog",
+            schema = "test_schema",
+            tableName = "test_table",
+            isTemp = false,
+            useIcebergFastPath = false,
+        )
+
+        verify(exactly = 0) { icebergMetadataReader.loadTableMetadata(any(), any(), any(), any()) }
+        verify(exactly = 1) { sparkMetadataReader.describeTable(sparkSession, "test_catalog", "test_schema", "test_table") }
     }
 
     // Additional: UNKNOWN type with iceberg provider gets promoted to MANAGED

--- a/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/TableMetadataExtractorTest.kt
+++ b/iomete-catalog-sync/src/test/kotlin/com/iomete/catalogsync/metadata/TableMetadataExtractorTest.kt
@@ -458,6 +458,47 @@ class TableMetadataExtractorTest {
     }
 
     @Test
+    fun `scrapeTable fast path promotes iceberg provider to managed when type metadata is absent`() {
+        val fastPathMetadata = IcebergLoadedTableMetadata(
+            tableDescription = TableDescription(
+                columns = listOf(ColumnMetadata("id", "int", null, 0, false)),
+                metadata = mapOf("Provider" to "iceberg"),
+            ),
+            tableProperties = emptyMap(),
+            statistics = null,
+        )
+        val extractor = mockk<TableExtractor>()
+
+        every {
+            icebergMetadataReader.loadTableMetadata(sparkSession, "cat", "sch", "tbl")
+        } returns fastPathMetadata
+        every {
+            tableExtractorFactory.extractorFor(
+                spark = sparkSession,
+                provider = "iceberg",
+                isView = false,
+                catalog = "cat",
+                schema = "sch",
+                table = "tbl",
+                tableProperties = emptyMap(),
+            )
+        } returns extractor
+
+        val result = tableMetadataExtractor.scrapeTable(
+            spark = sparkSession,
+            catalog = "cat",
+            schema = "sch",
+            tableName = "tbl",
+            isTemp = false,
+            useIcebergFastPath = true,
+        )
+
+        assertEquals("MANAGED", result.tableType)
+        assertFalse(result.isView)
+        verify(exactly = 0) { sparkMetadataReader.describeTable(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `scrapeTable fast path preserves complete output shape in regular test gate`() {
         val columns = listOf(
             ColumnMetadata("id", "bigint", "user id", 0, false),


### PR DESCRIPTION
## Summary

Implements Pillar A — cheaper per-table extraction for Iceberg catalogs in `iomete-catalog-sync` (PLA-461).

- **New `IcebergMetadataReader`**: loads Iceberg tables via `Spark3Util.loadIcebergTable` and extracts columns/types/comments, partition flags/spec, table comment/owner/properties, current snapshot metrics, and historical totals from snapshot summaries — replacing the per-table `DESCRIBE EXTENDED` + `$table.snapshots` Spark SQL pair.
- **Routing**: Iceberg catalog non-view tables use the fast path; any per-table failure logs a WARN and falls back to the existing Spark path. Views and non-Iceberg catalogs are unchanged.
- **Historical totals return `null`** if any `added-*` summary field is missing, preventing silent metric drift.
- **Version bump**: catalog-sync image tag `5.0.2` → `5.0.3`.

## Validation

- `./gradlew test` — passes (includes new unit tests for the reader, routing/fallback, and fast-path output shape/empty tables)
- `./gradlew integrationTest` — passes (fast path vs Spark path equivalence, PII tags, full pipeline metadata assertions)
- Tests assert the fast path issues no per-table `DESCRIBE EXTENDED` / `.snapshots` Spark SQL

## Risks

- Non-managed Iceberg-compatible catalogs also take the fast path when resolvable via `Spark3Util.loadIcebergTable`; this is intentional — per-table failures fall back to the Spark path.
- No manifest-reading APIs are used; metrics come from snapshot summaries only.

## Links

- Linear: PLA-461