### PR TITLE
feat: add HDFS (Isilon) backup target

### DIFF
--- a/iomete-lakehouse-backup/Dockerfile
+++ b/iomete-lakehouse-backup/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=InvalidDefaultArgInFrom
 # No default: Makefile injects SPARK_IMAGE from gradle.properties.
 ARG SPARK_IMAGE
 FROM ${SPARK_IMAGE}

--- a/iomete-lakehouse-backup/README.md
+++ b/iomete-lakehouse-backup/README.md
@@ -1,17 +1,19 @@
 # IOMETE Lakehouse Backup
 
-Copy your data from one S3 location to another, as a Spark job on IOMETE.
+Copy your data from an S3 source to an S3 or HDFS (Dell Isilon / OneFS) target,
+as a Spark job on IOMETE.
 
 ## Overview
 
-This job copies all the files from a source S3 location to a target S3 location.
-It runs the copy in parallel across your Spark cluster, so it scales with the
-size of the data. You set it up with a single JSON file and run it as a
-scheduled job on the IOMETE platform.
+This job copies all the files from a source S3 location to a target location
+(another S3 bucket, or an HDFS filesystem such as Dell Isilon). It runs the copy
+in parallel across your Spark cluster, so it scales with the size of the data.
+You set it up with a single JSON file and run it as a scheduled job on the
+IOMETE platform.
 
 ## What it does
 
-- Copies files between S3 locations (source and target)
+- Copies files from an S3 source to an S3 or HDFS target
 - Copies a folder and everything under it
 - Uses separate credentials for the source and the target (for example, a
   production account and a separate backup account)
@@ -57,6 +59,40 @@ The remaining S3 fields are optional and have sensible defaults: `prefix`
 (empty), `endpoint` (AWS default), `pathStyleAccess` (`false`), `region`
 (`us-east-1`). The job scales automatically with your Spark cluster, so there is
 nothing extra to tune.
+
+### HDFS target (Dell Isilon / OneFS)
+
+To back up into an HDFS filesystem, set the `target` to `type: "hdfs"`:
+
+```json
+{
+  "source": {
+    "type": "s3",
+    "bucket": "<source-bucket>",
+    "prefix": "<source-prefix>",
+    "accessKey": "${SOURCE_ACCESS_KEY}",
+    "secretKey": "${SOURCE_SECRET_KEY}"
+  },
+  "target": {
+    "type": "hdfs",
+    "namenode": "<host:port>",
+    "path": "<target-path>",
+    "user": "<hdfs-user>"
+  }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `namenode` | yes | NameNode RPC endpoint as `host:port` (e.g. `isilon.example.com:8020`). For Dell Isilon, prefer the SmartConnect zone FQDN so the connection is load-balanced across nodes. |
+| `path` | no (default empty) | Directory under the filesystem root to write into. |
+| `user` | yes | The identity the files are written as. HDFS `simple` authentication has no password — the job connects as this user and OneFS applies that user's POSIX permissions. Choose a user with write access to `path`. |
+| `authentication` | no (default `simple`) | Only `simple` is supported; any other value is rejected at validation. Kerberos/secure clusters are not yet supported. |
+
+> **Credentials for HDFS.** Simple authentication carries no secret or password
+> — only the `user` name — so there is nothing to store in IOMETE Secrets for
+> the target. Ensure the run has network reachability to the NameNode and every
+> DataNode in the cluster.
 
 ## Set up as a job in IOMETE
 

--- a/iomete-lakehouse-backup/README.md
+++ b/iomete-lakehouse-backup/README.md
@@ -99,7 +99,7 @@ To back up into an HDFS filesystem, set the `target` to `type: "hdfs"`:
 1. In the IOMETE console, navigate to **Spark → Jobs** and click **Create Job**.
 2. Fill in the job form:
    - **Docker Image:** `iomete.azurecr.io/iomete/iomete-lakehouse-backup:x.y.z`
-   - **Main Application File:** `local:///opt/spark/jars/iomete-lakehouse-backup.jar`
+   - **Main Application File:** `spark-internal`
    - **Main Class:** `com.iomete.backup.App`
    - **Arguments:** `/etc/configs/application.json`
 3. Choose the **Instance** size appropriate for the volume of data being copied.

--- a/iomete-lakehouse-backup/docs/local-debugging.md
+++ b/iomete-lakehouse-backup/docs/local-debugging.md
@@ -46,7 +46,7 @@ quick logic-only debugging where exact-parity is not required.
 
 The image tag is derived from `gradle.properties`
 (`sparkVersion` + `sparkImageRevision`), matching the `FROM` line in the
-`Dockerfile`. At the time of writing that is `spark:3.5.7-v3`; use whatever the
+`Dockerfile`. At the time of writing that is `spark:3.5.7-v2`; use whatever the
 current values are.
 
 ## One-time setup
@@ -54,7 +54,7 @@ current values are.
 ### 1. Extract the exact Spark distribution from the image
 
 ```bash
-docker create --name spark-extract iomete.azurecr.io/iomete/spark:3.5.7-v3
+docker create --name spark-extract iomete.azurecr.io/iomete/spark:3.5.7-v2
 docker cp spark-extract:/opt/spark ./.local-spark
 docker rm spark-extract
 ```

--- a/iomete-lakehouse-backup/gradle.properties
+++ b/iomete-lakehouse-backup/gradle.properties
@@ -7,6 +7,6 @@ kotlin.code.style=official
 # Single source of truth (build.gradle.kts + Makefile derive from this).
 projectVersion=1.0.0
 sparkVersion=3.5.7
-sparkImageRevision=v3
+sparkImageRevision=v2
 # Must match the iomete/spark base image
 hadoopAwsVersion=3.4.1

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
@@ -4,8 +4,8 @@ import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.copy.CopyJobRunner
 import com.iomete.backup.fs.FileEntry
 import com.iomete.backup.fs.FileLister
+import com.iomete.backup.fs.FileSystemFactory
 import com.iomete.backup.fs.HadoopConfigBuilder
-import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
@@ -61,7 +61,7 @@ object BackupJob {
         val sourceConf = HadoopConfigBuilder.build(config.source)
         val sourceRoot = config.source.rootUri
 
-        return FileSystem.newInstance(URI(sourceRoot), sourceConf).use { sourceFs ->
+        return FileSystemFactory.create(config.source, URI(sourceRoot), sourceConf).use { sourceFs ->
             FileLister(sourceFs).listRecursively(Path(sourceRoot)).toList()
         }
     }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
@@ -15,6 +15,7 @@ data class ApplicationConfig(
 )
 @JsonSubTypes(
     JsonSubTypes.Type(value = S3Config::class, name = "s3"),
+    JsonSubTypes.Type(value = HdfsConfig::class, name = "hdfs"),
 )
 sealed class StorageConfig : java.io.Serializable {
     abstract val rootUri: String
@@ -33,5 +34,18 @@ data class S3Config(
         get() {
             val trimmedPrefix = prefix.trim('/')
             return if (trimmedPrefix.isEmpty()) "s3a://$bucket" else "s3a://$bucket/$trimmedPrefix"
+        }
+}
+
+data class HdfsConfig(
+    val namenode: String,
+    val path: String = "",
+    val authentication: String = "simple",
+    val user: String,
+) : StorageConfig() {
+    override val rootUri: String
+        get() {
+            val trimmedPath = path.trim('/')
+            return if (trimmedPath.isEmpty()) "hdfs://$namenode" else "hdfs://$namenode/$trimmedPath"
         }
 }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Utils.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Utils.kt
@@ -1,6 +1,7 @@
 package com.iomete.backup.config.internal
 
 import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import com.iomete.backup.config.StorageConfig
 
@@ -20,6 +21,10 @@ object Utils {
                     accessKey = MASKED_VALUE,
                     secretKey = MASKED_VALUE,
                 )
+            }
+
+            is HdfsConfig -> {
+                storage
             }
         }
 }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
@@ -1,6 +1,7 @@
 package com.iomete.backup.config.internal
 
 import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import com.iomete.backup.config.StorageConfig
 import org.slf4j.LoggerFactory
@@ -31,6 +32,25 @@ object Validator {
     ) {
         when (storage) {
             is S3Config -> validateS3Config(storage, location, errors)
+            is HdfsConfig -> validateHdfsConfig(storage, location, errors)
+        }
+    }
+
+    private fun validateHdfsConfig(
+        config: HdfsConfig,
+        location: String,
+        errors: MutableList<String>,
+    ) {
+        if (config.namenode.isBlank()) {
+            errors.add("HDFS $location: namenode is required and cannot be empty")
+        }
+
+        if (config.user.isBlank()) {
+            errors.add("HDFS $location: user is required and cannot be empty")
+        }
+
+        if (config.authentication != "simple") {
+            errors.add("HDFS $location: authentication '${config.authentication}' is not supported (only 'simple')")
         }
     }
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
@@ -2,8 +2,8 @@ package com.iomete.backup.copy.internal
 
 import com.iomete.backup.config.StorageConfig
 import com.iomete.backup.copy.CopyResult
+import com.iomete.backup.fs.FileSystemFactory
 import com.iomete.backup.fs.HadoopConfigBuilder
-import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.FileUtil
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.security.AccessControlException
@@ -114,8 +114,8 @@ class FileCopier(
         val sourceConf = HadoopConfigBuilder.build(sourceConfig)
         val targetConf = HadoopConfigBuilder.build(targetConfig)
 
-        return FileSystem.newInstance(URI(sourceFilePath), sourceConf).use { sourceFs ->
-            FileSystem.newInstance(URI(targetFilePath), targetConf).use { targetFs ->
+        return FileSystemFactory.create(sourceConfig, URI(sourceFilePath), sourceConf).use { sourceFs ->
+            FileSystemFactory.create(targetConfig, URI(targetFilePath), targetConf).use { targetFs ->
                 val sourcePath = Path(sourceFilePath)
                 val targetPath = Path(targetFilePath)
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/fs/FileSystemFactory.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/fs/FileSystemFactory.kt
@@ -1,0 +1,22 @@
+package com.iomete.backup.fs
+
+import com.iomete.backup.config.HdfsConfig
+import com.iomete.backup.config.S3Config
+import com.iomete.backup.config.StorageConfig
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
+import java.net.URI
+
+object FileSystemFactory {
+    // HDFS simple auth carries identity as the username (3-arg factory);
+    // S3 uses the credentials already in conf.
+    fun create(
+        config: StorageConfig,
+        uri: URI,
+        conf: Configuration,
+    ): FileSystem =
+        when (config) {
+            is S3Config -> FileSystem.newInstance(uri, conf)
+            is HdfsConfig -> FileSystem.newInstance(uri, conf, config.user)
+        }
+}

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/fs/HadoopConfigBuilder.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/fs/HadoopConfigBuilder.kt
@@ -1,5 +1,6 @@
 package com.iomete.backup.fs
 
+import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import com.iomete.backup.config.StorageConfig
 import org.apache.hadoop.conf.Configuration
@@ -14,6 +15,7 @@ object HadoopConfigBuilder {
     private fun configMap(config: StorageConfig): Map<String, String> =
         when (config) {
             is S3Config -> s3ConfigMap(config)
+            is HdfsConfig -> hdfsConfigMap(config)
         }
 
     private fun s3ConfigMap(config: S3Config): Map<String, String> =
@@ -27,5 +29,11 @@ object HadoopConfigBuilder {
             put("fs.s3a.endpoint.region", config.region)
             put("fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
             put("fs.s3a.connection.ssl.enabled", (config.endpoint?.startsWith("https") ?: true).toString())
+        }
+
+    private fun hdfsConfigMap(config: HdfsConfig): Map<String, String> =
+        buildMap {
+            put("fs.defaultFS", "hdfs://${config.namenode}")
+            put("hadoop.security.authentication", config.authentication)
         }
 }

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/HdfsConfigTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/HdfsConfigTest.kt
@@ -1,0 +1,49 @@
+package com.iomete.backup.config
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class HdfsConfigTest {
+    @Test
+    fun `HDFS config with path produces hdfs URI`() {
+        val config =
+            HdfsConfig(
+                namenode = "isilon.example.com:8020",
+                path = "backups/warehouse",
+                user = "isilon-user",
+            )
+        assertEquals("hdfs://isilon.example.com:8020/backups/warehouse", config.rootUri)
+    }
+
+    @Test
+    fun `HDFS config without path produces namenode-only URI`() {
+        val config =
+            HdfsConfig(
+                namenode = "isilon.example.com:8020",
+                path = "",
+                user = "isilon-user",
+            )
+        assertEquals("hdfs://isilon.example.com:8020", config.rootUri)
+    }
+
+    @Test
+    fun `HDFS config trims leading and trailing slashes from path`() {
+        val config =
+            HdfsConfig(
+                namenode = "isilon.example.com:8020",
+                path = "/backups/warehouse/",
+                user = "isilon-user",
+            )
+        assertEquals("hdfs://isilon.example.com:8020/backups/warehouse", config.rootUri)
+    }
+
+    @Test
+    fun `HDFS config carries the configured user`() {
+        val config =
+            HdfsConfig(
+                namenode = "isilon.example.com:8020",
+                user = "isilon-user",
+            )
+        assertEquals("isilon-user", config.user)
+    }
+}

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ParserTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ParserTest.kt
@@ -1,6 +1,7 @@
 package com.iomete.backup.config.internal
 
 import com.iomete.backup.config.ConfigParseException
+import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -48,6 +49,53 @@ class ParserTest {
         val target = config.target as S3Config
         assertEquals("target-bucket", target.bucket)
         assertEquals("backup/", target.prefix)
+    }
+
+    @Test
+    fun `parse S3-to-HDFS config binds HdfsConfig target`() {
+        val json =
+            """
+            {
+              "source": {
+                "type": "s3",
+                "bucket": "source-bucket",
+                "prefix": "data/",
+                "accessKey": "access123",
+                "secretKey": "secret456"
+              },
+              "target": {
+                "type": "hdfs",
+                "namenode": "isilon.example.com:8020",
+                "path": "backups",
+                "user": "isilon-user"
+              }
+            }
+            """.trimIndent()
+
+        val config = Parser.parse(json)
+
+        assertIs<S3Config>(config.source)
+        assertIs<HdfsConfig>(config.target)
+
+        val target = config.target as HdfsConfig
+        assertEquals("isilon.example.com:8020", target.namenode)
+        assertEquals("backups", target.path)
+        assertEquals("isilon-user", target.user)
+        assertEquals("simple", target.authentication) // default
+    }
+
+    @Test
+    fun `HDFS config missing user names the field`() {
+        val json =
+            """
+            {
+              "source": { "type": "s3", "bucket": "b", "accessKey": "k", "secretKey": "s" },
+              "target": { "type": "hdfs", "namenode": "isilon.example.com:8020" }
+            }
+            """.trimIndent()
+
+        val e = assertThrows<ConfigParseException> { Parser.parse(json) }
+        assertEquals("Missing required field 'target.user'", e.message)
     }
 
     @Test

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/UtilsTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/UtilsTest.kt
@@ -1,9 +1,11 @@
 package com.iomete.backup.config.internal
 
 import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 
 class UtilsTest {
     @Test
@@ -37,5 +39,30 @@ class UtilsTest {
         assertEquals("target-bucket", target.bucket)
         assertEquals("********", target.accessKey)
         assertEquals("********", target.secretKey)
+    }
+
+    @Test
+    fun `redactSecrets leaves HDFS target unchanged`() {
+        val hdfsTarget =
+            HdfsConfig(
+                namenode = "isilon.example.com:8020",
+                path = "backups",
+                user = "isilon-user",
+            )
+        val config =
+            ApplicationConfig(
+                source =
+                    S3Config(
+                        bucket = "source-bucket",
+                        accessKey = "AKIAIOSFODNN7EXAMPLE",
+                        secretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    ),
+                target = hdfsTarget,
+            )
+
+        val redacted = Utils.redactSecrets(config)
+
+        assertSame(hdfsTarget, redacted.target)
+        assertEquals("********", (redacted.source as S3Config).accessKey)
     }
 }

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
@@ -1,6 +1,7 @@
 package com.iomete.backup.config.internal
 
 import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import org.junit.jupiter.api.Test
 import kotlin.test.assertIs
@@ -22,6 +23,18 @@ class ValidatorTest {
         secretKey = secretKey,
         endpoint = endpoint,
         pathStyleAccess = pathStyleAccess,
+    )
+
+    private fun hdfsConfig(
+        namenode: String = "isilon.example.com:8020",
+        path: String = "backups",
+        authentication: String = "simple",
+        user: String = "isilon-user",
+    ) = HdfsConfig(
+        namenode = namenode,
+        path = path,
+        authentication = authentication,
+        user = user,
     )
 
     @Test
@@ -77,5 +90,60 @@ class ValidatorTest {
 
         assertIs<ValidationResult.Invalid>(result)
         assertTrue(result.errors.any { it.contains("secretKey") && it.contains("target") })
+    }
+
+    @Test
+    fun `valid S3-to-HDFS config passes validation`() {
+        val config =
+            ApplicationConfig(
+                source = s3Config(bucket = "source-bucket"),
+                target = hdfsConfig(),
+            )
+
+        val result = Validator.validate(config)
+
+        assertIs<ValidationResult.Valid>(result)
+    }
+
+    @Test
+    fun `HDFS with blank namenode fails validation`() {
+        val config =
+            ApplicationConfig(
+                source = s3Config(),
+                target = hdfsConfig(namenode = ""),
+            )
+
+        val result = Validator.validate(config)
+
+        assertIs<ValidationResult.Invalid>(result)
+        assertTrue(result.errors.any { it.contains("namenode") && it.contains("target") })
+    }
+
+    @Test
+    fun `HDFS with blank user fails validation`() {
+        val config =
+            ApplicationConfig(
+                source = s3Config(),
+                target = hdfsConfig(user = ""),
+            )
+
+        val result = Validator.validate(config)
+
+        assertIs<ValidationResult.Invalid>(result)
+        assertTrue(result.errors.any { it.contains("user") && it.contains("target") })
+    }
+
+    @Test
+    fun `HDFS with unsupported authentication fails validation`() {
+        val config =
+            ApplicationConfig(
+                source = s3Config(),
+                target = hdfsConfig(authentication = "kerberos"),
+            )
+
+        val result = Validator.validate(config)
+
+        assertIs<ValidationResult.Invalid>(result)
+        assertTrue(result.errors.any { it.contains("authentication") && it.contains("target") })
     }
 }

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/FileCopierTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/FileCopierTest.kt
@@ -1,5 +1,6 @@
 package com.iomete.backup.copy.internal
 
+import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import io.mockk.every
 import io.mockk.just
@@ -435,6 +436,65 @@ class FileCopierTest {
             verify(exactly = 1) { FileSystem.newInstance(URI(sourcePathString), any<Configuration>()) }
             verify(exactly = 1) { FileSystem.newInstance(URI(targetPathString), any<Configuration>()) }
             verify(exactly = 0) { FileSystem.get(any<URI>(), any<Configuration>()) }
+            verify(exactly = 1) { targetFs.close() }
+            verify(exactly = 1) { sourceFs.close() }
+        } finally {
+            unmockkStatic(FileUtil::class)
+            unmockkStatic(FileSystem::class)
+        }
+    }
+
+    @Test
+    fun `HDFS target filesystem is built with the configured user`() {
+        val sourcePathString = "s3a://source-bucket/in/file.txt"
+        val targetPathString = "hdfs://isilon.example.com:8020/out/file.txt"
+        val sourcePath = Path(sourcePathString)
+        val targetPath = Path(targetPathString)
+        val targetParent = Path("hdfs://isilon.example.com:8020/out")
+        val sourceFs = mockk<FileSystem>()
+        val targetFs = mockk<FileSystem>()
+
+        mockkStatic(FileSystem::class)
+        mockkStatic(FileUtil::class)
+
+        try {
+            every { FileSystem.newInstance(URI(sourcePathString), any<Configuration>()) } returns sourceFs
+            every {
+                FileSystem.newInstance(URI(targetPathString), any<Configuration>(), "isilon-user")
+            } returns targetFs
+            every { targetFs.exists(targetParent) } returns true
+            every { sourceFs.getFileStatus(sourcePath) } returns FileStatus(11L, false, 1, 1024L, 0L, sourcePath)
+            every { FileUtil.copy(sourceFs, sourcePath, targetFs, targetPath, false, true, any()) } returns true
+            every { sourceFs.close() } just runs
+            every { targetFs.close() } just runs
+
+            val copier =
+                FileCopier(
+                    sourceConfig =
+                        S3Config(
+                            bucket = "source-bucket",
+                            accessKey = "key",
+                            secretKey = "secret",
+                        ),
+                    targetConfig =
+                        HdfsConfig(
+                            namenode = "isilon.example.com:8020",
+                            path = "out",
+                            user = "isilon-user",
+                        ),
+                    sourceRoot = "s3a://source-bucket/in",
+                    targetRoot = "hdfs://isilon.example.com:8020/out",
+                )
+
+            val result = copier.copySingleFile(sourcePathString)
+
+            assertTrue(result.success)
+            assertEquals(targetPathString, result.targetPath)
+            assertEquals(11L, result.bytesCopied)
+            verify(exactly = 1) {
+                FileSystem.newInstance(URI(targetPathString), any<Configuration>(), "isilon-user")
+            }
+            verify(exactly = 0) { FileSystem.newInstance(URI(targetPathString), any<Configuration>()) }
             verify(exactly = 1) { targetFs.close() }
             verify(exactly = 1) { sourceFs.close() }
         } finally {

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/fs/FileSystemFactoryTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/fs/FileSystemFactoryTest.kt
@@ -1,0 +1,65 @@
+package com.iomete.backup.fs
+
+import com.iomete.backup.config.HdfsConfig
+import com.iomete.backup.config.S3Config
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.test.assertSame
+
+class FileSystemFactoryTest {
+    @Test
+    fun `S3 config builds a filesystem without binding a user`() {
+        val uri = URI("s3a://bucket/path")
+        val conf = Configuration()
+        val fs = mockk<FileSystem>()
+
+        mockkStatic(FileSystem::class)
+        try {
+            every { FileSystem.newInstance(uri, conf) } returns fs
+
+            val result =
+                FileSystemFactory.create(
+                    S3Config(bucket = "bucket", accessKey = "k", secretKey = "s"),
+                    uri,
+                    conf,
+                )
+
+            assertSame(fs, result)
+            verify(exactly = 1) { FileSystem.newInstance(uri, conf) }
+        } finally {
+            unmockkStatic(FileSystem::class)
+        }
+    }
+
+    @Test
+    fun `HDFS config builds a filesystem bound to the configured user`() {
+        val uri = URI("hdfs://isilon.example.com:8020/path")
+        val conf = Configuration()
+        val fs = mockk<FileSystem>()
+
+        mockkStatic(FileSystem::class)
+        try {
+            every { FileSystem.newInstance(uri, conf, "isilon-user") } returns fs
+
+            val result =
+                FileSystemFactory.create(
+                    HdfsConfig(namenode = "isilon.example.com:8020", user = "isilon-user"),
+                    uri,
+                    conf,
+                )
+
+            assertSame(fs, result)
+            verify(exactly = 1) { FileSystem.newInstance(uri, conf, "isilon-user") }
+            verify(exactly = 0) { FileSystem.newInstance(uri, conf) }
+        } finally {
+            unmockkStatic(FileSystem::class)
+        }
+    }
+}

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/fs/HadoopConfigBuilderTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/fs/HadoopConfigBuilderTest.kt
@@ -1,5 +1,6 @@
 package com.iomete.backup.fs
 
+import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -128,6 +129,36 @@ class HadoopConfigBuilderTest {
             assertEquals("target-key", targetConf.get("fs.s3a.access.key"))
             assertEquals("target-secret", targetConf.get("fs.s3a.secret.key"))
             assertEquals("https://target.example.com", targetConf.get("fs.s3a.endpoint"))
+        }
+    }
+
+    @Nested
+    inner class HdfsConfigTests {
+        @Test
+        fun `HDFS config sets defaultFS and authentication`() {
+            val config =
+                HdfsConfig(
+                    namenode = "isilon.example.com:8020",
+                    path = "backups",
+                    authentication = "simple",
+                    user = "isilon-user",
+                )
+            val conf = HadoopConfigBuilder.build(config)
+
+            assertEquals("hdfs://isilon.example.com:8020", conf.get("fs.defaultFS"))
+            assertEquals("simple", conf.get("hadoop.security.authentication"))
+        }
+
+        @Test
+        fun `HDFS config does not set datanode hostname flag`() {
+            val config =
+                HdfsConfig(
+                    namenode = "isilon.example.com:8020",
+                    user = "isilon-user",
+                )
+            val conf = HadoopConfigBuilder.build(config)
+
+            assertNull(conf.get("dfs.client.use.datanode.hostname"))
         }
     }
 }


### PR DESCRIPTION
### Summary
Add HDFS (Dell Isilon / OneFS) as a backup target alongside the existing S3-to-S3 path, reusing the same distributed copy engine. Enables backing up lakehouse data to on-prem Isilon storage with no change to S3 behavior and no new dependencies.

### Context
The job could only copy files between S3 locations. Customers running on-prem need to back up to HDFS-compatible Dell Isilon storage. HDFS requires storage-specific FileSystem construction — simple auth threads the user identity as the username on executors — which the S3-only path did not accommodate.

### Implementation
- New `HdfsConfig` sealed subtype of `StorageConfig` (`namenode`, `path`, `authentication` defaulting to `simple`, required `user`); `rootUri` = `hdfs://<namenode>/<path>`.
- `FileSystemFactory` centralizes FileSystem creation via a sealed `when`: S3 → 2-arg `newInstance`, HDFS → 3-arg `newInstance(uri, conf, user)`. `BackupJob` and `FileCopier` route through it, keeping the copy engine free of per-storage knowledge; `user` stays off the base `StorageConfig` to avoid a leaky abstraction.
- `HadoopConfigBuilder` emits `fs.defaultFS` + `hadoop.security.authentication`; deliberately omits `dfs.client.use.datanode.hostname` (OneFS SmartConnect returns routable front-end IPs).
- Validation requires non-blank `namenode` and `user` and rejects any authentication other than `simple` (Kerberos unimplemented); redaction returns `HdfsConfig` unchanged (no secret).
- README documents the HDFS target; unit tests added at each seam (config parse/validate/redact, `HadoopConfigBuilder`, `FileSystemFactory`, `FileCopier`).
