### PR TITLE
feat(lakehouse-backup): integration harness (MinIO + MiniDFS) + CI gate

### DIFF
--- a/.github/workflows/lakehouse_backup_tests.yml
+++ b/.github/workflows/lakehouse_backup_tests.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           report_paths: 'iomete-lakehouse-backup/build/test-results/**/*.xml'
           detailed_summary: true
-          include_passed: true
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/lakehouse_backup_tests.yml
+++ b/.github/workflows/lakehouse_backup_tests.yml
@@ -1,0 +1,61 @@
+name: Lakehouse Backup Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'iomete-lakehouse-backup/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'iomete-lakehouse-backup/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: iomete-lakehouse-backup
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('iomete-lakehouse-backup/**/*.gradle*', 'iomete-lakehouse-backup/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Run integration tests
+        run: ./gradlew integrationTest
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports
+          path: |
+            iomete-lakehouse-backup/build/reports/tests/test/
+            iomete-lakehouse-backup/build/reports/tests/integrationTest/
+          retention-days: 7

--- a/.github/workflows/lakehouse_backup_tests.yml
+++ b/.github/workflows/lakehouse_backup_tests.yml
@@ -58,6 +58,8 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: 'iomete-lakehouse-backup/build/test-results/**/*.xml'
+          detailed_summary: true
+          include_passed: true
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/lakehouse_backup_tests.yml
+++ b/.github/workflows/lakehouse_backup_tests.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     defaults:
       run:
         working-directory: iomete-lakehouse-backup
@@ -50,6 +53,12 @@ jobs:
       - name: Run integration tests
         run: ./gradlew integrationTest
 
+      - name: Publish test report
+        if: always()
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: 'iomete-lakehouse-backup/build/test-results/**/*.xml'
+
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v7
@@ -58,4 +67,4 @@ jobs:
           path: |
             iomete-lakehouse-backup/build/reports/tests/test/
             iomete-lakehouse-backup/build/reports/tests/integrationTest/
-          retention-days: 7
+          retention-days: 3

--- a/iomete-lakehouse-backup/build.gradle.kts
+++ b/iomete-lakehouse-backup/build.gradle.kts
@@ -1,9 +1,9 @@
-import org.gradle.api.tasks.testing.Test
+import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.4.0"
+    kotlin("jvm") version "2.4.10"
     application
 }
 
@@ -34,29 +34,62 @@ repositories {
     mavenCentral()
 }
 
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class) {
+            useJUnitJupiter("6.1.2")
+        }
+
+        // Own source set + classpath: keeps the unshaded Hadoop (see below) off the unit-test classpath.
+        register<JvmTestSuite>("integrationTest") {
+            useJUnitJupiter("6.1.2")
+            dependencies {
+                implementation(project())
+
+                // Spark's shaded hadoop-client (3.3.4) relocates protobuf and breaks MiniDFSCluster;
+                // exclude it and pull unshaded Hadoop 3.4.1 (matching the hadoop-aws pin) instead.
+                implementation("org.apache.spark:spark-sql_2.12:$sparkVersion") {
+                    exclude(group = "org.apache.hadoop", module = "hadoop-client-api")
+                    exclude(group = "org.apache.hadoop", module = "hadoop-client-runtime")
+                }
+                implementation("org.apache.hadoop:hadoop-client:$hadoopAwsVersion")
+                implementation("org.apache.hadoop:hadoop-aws:$hadoopAwsVersion")
+                implementation("org.apache.hadoop:hadoop-minicluster:$hadoopAwsVersion")
+                runtimeOnly("org.mockito:mockito-core:5.23.0") // MiniDFSCluster uses Mockito internally
+                implementation("org.testcontainers:junit-jupiter:1.21.4")
+                implementation("org.testcontainers:minio:1.21.4")
+                implementation("software.amazon.awssdk:s3:2.49.1")
+                implementation("org.jetbrains.kotlin:kotlin-test")
+            }
+            targets {
+                all {
+                    testTask.configure {
+                        jvmArgs(sparkJvmArgs)
+                        shouldRunAfter(test)
+                        testLogging {
+                            events("passed", "skipped", "failed")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 dependencies {
-    // JSON parsing
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.22.1")
 
-    // Logging
     implementation("org.slf4j:slf4j-api:2.0.18")
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:2.26.1")
     runtimeOnly("org.apache.logging.log4j:log4j-core:2.26.1")
 
-    // Provided at runtime by the Spark base image
+    // compileOnly: the Spark base image provides these at runtime.
     compileOnly("org.apache.spark:spark-sql_2.12:$sparkVersion")
     compileOnly("org.apache.hadoop:hadoop-aws:$hadoopAwsVersion")
 
-    // Testing
-    testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")
     testImplementation("io.mockk:mockk:1.14.11")
     testImplementation("org.apache.spark:spark-sql_2.12:$sparkVersion")
-    testImplementation("org.apache.hadoop:hadoop-aws:$hadoopAwsVersion")
-    testImplementation("org.testcontainers:junit-jupiter:1.21.4")
-    testImplementation("org.testcontainers:minio:1.21.4")
-    testImplementation("software.amazon.awssdk:s3:2.47.5")
     testImplementation(kotlin("test"))
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 application {
@@ -73,27 +106,6 @@ tasks.withType<KotlinCompile> {
 
 tasks.test {
     jvmArgs(sparkJvmArgs)
-    useJUnitPlatform {
-        excludeTags("integration")
-    }
-    testLogging {
-        events("passed", "skipped", "failed")
-    }
-}
-
-tasks.register<Test>("integrationTest") {
-    description = "Runs Docker-backed integration tests."
-    group = "verification"
-    testClassesDirs =
-        sourceSets.test
-            .get()
-            .output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs(sparkJvmArgs)
-    shouldRunAfter(tasks.test)
-    useJUnitPlatform {
-        includeTags("integration")
-    }
     testLogging {
         events("passed", "skipped", "failed")
     }

--- a/iomete-lakehouse-backup/build.gradle.kts
+++ b/iomete-lakehouse-backup/build.gradle.kts
@@ -89,6 +89,9 @@ dependencies {
 
     testImplementation("io.mockk:mockk:1.14.11")
     testImplementation("org.apache.spark:spark-sql_2.12:$sparkVersion")
+    // Pin the shaded Hadoop client to the base image's version (overrides Spark's transitive 3.3.4).
+    testImplementation("org.apache.hadoop:hadoop-client-api:$hadoopAwsVersion")
+    testImplementation("org.apache.hadoop:hadoop-client-runtime:$hadoopAwsVersion")
     testImplementation(kotlin("test"))
 }
 

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import java.util.UUID
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class BackupJobIntegrationTest {
@@ -58,6 +60,22 @@ class BackupJobIntegrationTest {
         )
 
         assertTrue(readS3(target).isEmpty(), "empty source must not write to target")
+    }
+
+    @Test
+    fun `a failed copy surfaces as IllegalStateException from the entry point`() {
+        val source = IntegrationHarness.freshBucket()
+        seedS3(source, mapOf("root.txt" to "payload".toByteArray()))
+
+        // Target bucket is never created, so every write fails -> the job's failure check throws.
+        val missingTarget = IntegrationHarness.s3Config("missing-${UUID.randomUUID()}")
+
+        assertFailsWith<IllegalStateException> {
+            BackupJob.run(
+                IntegrationHarness.spark,
+                ApplicationConfig(source = IntegrationHarness.s3Config(source), target = missingTarget),
+            )
+        }
     }
 
     companion object {

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
@@ -1,0 +1,68 @@
+package com.iomete.backup.integration
+
+import com.iomete.backup.BackupJob
+import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.integration.fixtures.assertMatches
+import com.iomete.backup.integration.fixtures.fixture
+import com.iomete.backup.integration.fixtures.readHdfs
+import com.iomete.backup.integration.fixtures.readS3
+import com.iomete.backup.integration.fixtures.seedS3
+import com.iomete.backup.integration.harness.IntegrationHarness
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class BackupJobIntegrationTest {
+    @Test
+    fun `s3 to s3 happy path copies every file byte-for-byte`() {
+        val source = IntegrationHarness.freshBucket()
+        val target = IntegrationHarness.freshBucket()
+        val tree = fixture()
+
+        seedS3(source, tree)
+
+        BackupJob.run(
+            IntegrationHarness.spark,
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = IntegrationHarness.s3Config(target),
+            ),
+        )
+
+        assertMatches(tree, readS3(target))
+    }
+
+    @Test
+    fun `s3 to hdfs happy path copies every file byte-for-byte`() {
+        val source = IntegrationHarness.freshBucket()
+        val target = IntegrationHarness.freshHdfsPath()
+        val tree = fixture()
+
+        seedS3(source, tree)
+
+        BackupJob.run(
+            IntegrationHarness.spark,
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = IntegrationHarness.hdfsConfig(target),
+            ),
+        )
+
+        assertMatches(tree, readHdfs(target))
+    }
+
+    @Test
+    fun `empty source is a no-op and writes nothing`() {
+        val source = IntegrationHarness.freshBucket()
+        val target = IntegrationHarness.freshBucket()
+
+        BackupJob.run(
+            IntegrationHarness.spark,
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = IntegrationHarness.s3Config(target),
+            ),
+        )
+
+        assertTrue(readS3(target).isEmpty(), "empty source must not write to target")
+    }
+}

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.iomete.backup.integration
 
 import com.iomete.backup.BackupJob
 import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.StorageConfig
 import com.iomete.backup.integration.fixtures.assertMatches
 import com.iomete.backup.integration.fixtures.fixture
 import com.iomete.backup.integration.fixtures.readHdfs
@@ -9,45 +10,38 @@ import com.iomete.backup.integration.fixtures.readS3
 import com.iomete.backup.integration.fixtures.seedS3
 import com.iomete.backup.integration.harness.IntegrationHarness
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import kotlin.test.assertTrue
 
 class BackupJobIntegrationTest {
-    @Test
-    fun `s3 to s3 happy path copies every file byte-for-byte`() {
+    class Target(
+        val config: StorageConfig,
+        val read: () -> Map<String, ByteArray>,
+    )
+
+    @ParameterizedTest(name = "s3 to {0} happy path copies every file byte-for-byte")
+    @MethodSource("targets")
+    fun happyPath(
+        @Suppress("UNUSED_PARAMETER") name: String,
+        makeTarget: () -> Target,
+    ) {
         val source = IntegrationHarness.freshBucket()
-        val target = IntegrationHarness.freshBucket()
         val tree = fixture()
 
         seedS3(source, tree)
 
+        val target = makeTarget()
         BackupJob.run(
             IntegrationHarness.spark,
             ApplicationConfig(
                 source = IntegrationHarness.s3Config(source),
-                target = IntegrationHarness.s3Config(target),
+                target = target.config,
             ),
         )
 
-        assertMatches(tree, readS3(target))
-    }
-
-    @Test
-    fun `s3 to hdfs happy path copies every file byte-for-byte`() {
-        val source = IntegrationHarness.freshBucket()
-        val target = IntegrationHarness.freshHdfsPath()
-        val tree = fixture()
-
-        seedS3(source, tree)
-
-        BackupJob.run(
-            IntegrationHarness.spark,
-            ApplicationConfig(
-                source = IntegrationHarness.s3Config(source),
-                target = IntegrationHarness.hdfsConfig(target),
-            ),
-        )
-
-        assertMatches(tree, readHdfs(target))
+        assertMatches(tree, target.read())
     }
 
     @Test
@@ -64,5 +58,20 @@ class BackupJobIntegrationTest {
         )
 
         assertTrue(readS3(target).isEmpty(), "empty source must not write to target")
+    }
+
+    companion object {
+        @JvmStatic
+        fun targets(): List<Arguments> {
+            val s3: () -> Target = {
+                val bucket = IntegrationHarness.freshBucket()
+                Target(IntegrationHarness.s3Config(bucket)) { readS3(bucket) }
+            }
+            val hdfs: () -> Target = {
+                val path = IntegrationHarness.freshHdfsPath()
+                Target(IntegrationHarness.hdfsConfig(path)) { readHdfs(path) }
+            }
+            return listOf(Arguments.of("s3", s3), Arguments.of("hdfs", hdfs))
+        }
     }
 }

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/fixtures/StorageFixtures.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/fixtures/StorageFixtures.kt
@@ -1,0 +1,102 @@
+package com.iomete.backup.integration.fixtures
+
+import com.iomete.backup.integration.harness.IntegrationHarness
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.Path
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import kotlin.random.Random
+import kotlin.test.assertEquals
+
+/**
+ * Deterministic seed tree exercising path-resolution edge cases. The returned map doubles as the
+ * expected target state, so verification is byte-for-byte against exactly what was seeded.
+ */
+fun fixture(): Map<String, ByteArray> =
+    linkedMapOf(
+        "root.txt" to "root file".toByteArray(),
+        "data/warehouse/table/metadata/v1.metadata.json" to "{\"format\":1}".toByteArray(),
+        "data/warehouse/table/data/part-00000.parquet" to "PAR1..payload..PAR1".toByteArray(),
+        "empty.txt" to ByteArray(0),
+        "with space/file name.txt" to "spaced".toByteArray(),
+        "unicode/файл-数据-δ.txt" to "unicode".toByteArray(),
+        "big/random.bin" to Random(42).nextBytes(5 * 1024 * 1024),
+    )
+
+/** Write a key -> bytes map into an S3 bucket. */
+fun seedS3(
+    bucket: String,
+    tree: Map<String, ByteArray>,
+) {
+    tree.forEach { (key, bytes) ->
+        IntegrationHarness.s3.putObject(
+            { it.bucket(bucket).key(key) },
+            RequestBody.fromBytes(bytes),
+        )
+    }
+}
+
+/** Read every object in a bucket back as key -> bytes. */
+fun readS3(bucket: String): Map<String, ByteArray> {
+    val result = linkedMapOf<String, ByteArray>()
+    var token: String? = null
+
+    do {
+        val resp =
+            IntegrationHarness.s3.listObjectsV2(
+                ListObjectsV2Request
+                    .builder()
+                    .bucket(bucket)
+                    .continuationToken(token)
+                    .build(),
+            )
+        resp.contents().filterNot { it.key().endsWith("/") }.forEach { obj ->
+            result[obj.key()] =
+                IntegrationHarness.s3.getObjectAsBytes { it.bucket(bucket).key(obj.key()) }.asByteArray()
+        }
+        token = if (resp.isTruncated) resp.nextContinuationToken() else null
+    } while (token != null)
+
+    return result
+}
+
+/** Read every file under an HDFS path back as key -> bytes, keyed relative to the path. */
+fun readHdfs(path: String): Map<String, ByteArray> {
+    val fs = IntegrationHarness.hdfs.fileSystem
+    val root = Path("hdfs://localhost:${IntegrationHarness.hdfs.nameNodePort}/$path")
+
+    if (!fs.exists(root)) return emptyMap()
+
+    val result = linkedMapOf<String, ByteArray>()
+    val rootStr = root.toUri().path.trimEnd('/')
+    val it = fs.listFiles(root, true)
+
+    while (it.hasNext()) {
+        val status = it.next()
+        val key =
+            status.path
+                .toUri()
+                .path
+                .removePrefix("$rootStr/")
+        result[key] = readAll(fs, status.path)
+    }
+
+    return result
+}
+
+private fun readAll(
+    fs: FileSystem,
+    path: Path,
+): ByteArray = fs.open(path).use { it.readBytes() }
+
+/** Assert exact key set and byte-for-byte content. Both missing and extra files fail. */
+fun assertMatches(
+    expected: Map<String, ByteArray>,
+    actual: Map<String, ByteArray>,
+) {
+    assertEquals(expected.keys, actual.keys, "target key set mismatch")
+
+    expected.forEach { (key, bytes) ->
+        assertEquals(bytes.toList(), actual.getValue(key).toList(), "content mismatch for $key")
+    }
+}

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/fixtures/StorageFixtures.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/fixtures/StorageFixtures.kt
@@ -69,10 +69,10 @@ fun readHdfs(path: String): Map<String, ByteArray> {
 
     val result = linkedMapOf<String, ByteArray>()
     val rootStr = root.toUri().path.trimEnd('/')
-    val it = fs.listFiles(root, true)
+    val iter = fs.listFiles(root, true)
 
-    while (it.hasNext()) {
-        val status = it.next()
+    while (iter.hasNext()) {
+        val status = iter.next()
         val key =
             status.path
                 .toUri()

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
@@ -1,0 +1,85 @@
+package com.iomete.backup.integration.harness
+
+import com.iomete.backup.config.HdfsConfig
+import com.iomete.backup.config.S3Config
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.apache.spark.sql.SparkSession
+import org.testcontainers.containers.MinIOContainer
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import java.net.URI
+import java.util.UUID
+
+/**
+ * Suite-wide singletons: one MinIO container, one MiniDFSCluster, one local SparkSession.
+ * Started lazily on first access and shared by every integration test.
+ */
+object IntegrationHarness {
+    private const val REGION = "us-east-1"
+
+    val minio: MinIOContainer by lazy {
+        MinIOContainer("minio/minio:RELEASE.2025-09-07T16-13-09Z").also { it.start() }
+    }
+
+    val hdfs: MiniDFSCluster by lazy {
+        val baseDir = java.io.File("build/test/minidfs-${UUID.randomUUID()}").absolutePath
+        val conf = Configuration()
+        conf.set("hdfs.minidfs.basedir", baseDir)
+        MiniDFSCluster
+            .Builder(conf)
+            .numDataNodes(1)
+            .build()
+            .also { it.waitClusterUp() }
+    }
+
+    val spark: SparkSession by lazy {
+        SparkSession
+            .builder()
+            .appName("backup-integration")
+            .master("local[2]")
+            .config("spark.ui.enabled", "false")
+            .config("spark.sql.shuffle.partitions", "2")
+            .orCreate
+    }
+
+    val s3: S3Client by lazy {
+        S3Client
+            .builder()
+            .endpointOverride(URI(minio.s3URL))
+            .region(Region.of(REGION))
+            .forcePathStyle(true)
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(minio.userName, minio.password),
+                ),
+            ).build()
+    }
+
+    fun s3Config(bucket: String): S3Config =
+        S3Config(
+            bucket = bucket,
+            endpoint = minio.s3URL,
+            pathStyleAccess = true,
+            accessKey = minio.userName,
+            secretKey = minio.password,
+            region = REGION,
+        )
+
+    fun hdfsConfig(path: String): HdfsConfig {
+        val namenode = "localhost:${hdfs.nameNodePort}"
+        return HdfsConfig(namenode = namenode, path = path, user = System.getProperty("user.name"))
+    }
+
+    /** A fresh, empty bucket for one test. */
+    fun freshBucket(): String {
+        val bucket = "it-${UUID.randomUUID()}"
+        s3.createBucket { it.bucket(bucket) }
+        return bucket
+    }
+
+    /** A fresh HDFS target path for one test (not created; the job creates parents). */
+    fun freshHdfsPath(): String = "backup-it/${UUID.randomUUID()}"
+}

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
@@ -10,6 +10,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+import java.io.File
 import java.net.URI
 import java.util.UUID
 
@@ -26,7 +27,7 @@ object IntegrationHarness {
 
     private val hdfsLazy =
         lazy {
-            val baseDir = java.io.File("build/test/minidfs-${UUID.randomUUID()}").absolutePath
+            val baseDir = File("build/test/minidfs-${UUID.randomUUID()}").absolutePath
             val conf = Configuration()
             conf.set("hdfs.minidfs.basedir", baseDir)
             MiniDFSCluster

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
@@ -20,42 +20,59 @@ import java.util.UUID
 object IntegrationHarness {
     private const val REGION = "us-east-1"
 
-    val minio: MinIOContainer by lazy {
-        MinIOContainer("minio/minio:RELEASE.2025-09-07T16-13-09Z").also { it.start() }
-    }
+    private val minioLazy =
+        lazy { MinIOContainer("minio/minio:RELEASE.2025-09-07T16-13-09Z").also { it.start() } }
+    val minio: MinIOContainer by minioLazy
 
-    val hdfs: MiniDFSCluster by lazy {
-        val baseDir = java.io.File("build/test/minidfs-${UUID.randomUUID()}").absolutePath
-        val conf = Configuration()
-        conf.set("hdfs.minidfs.basedir", baseDir)
-        MiniDFSCluster
-            .Builder(conf)
-            .numDataNodes(1)
-            .build()
-            .also { it.waitClusterUp() }
-    }
+    private val hdfsLazy =
+        lazy {
+            val baseDir = java.io.File("build/test/minidfs-${UUID.randomUUID()}").absolutePath
+            val conf = Configuration()
+            conf.set("hdfs.minidfs.basedir", baseDir)
+            MiniDFSCluster
+                .Builder(conf)
+                .numDataNodes(1)
+                .build()
+                .also { it.waitClusterUp() }
+        }
+    val hdfs: MiniDFSCluster by hdfsLazy
 
-    val spark: SparkSession by lazy {
-        SparkSession
-            .builder()
-            .appName("backup-integration")
-            .master("local[2]")
-            .config("spark.ui.enabled", "false")
-            .config("spark.sql.shuffle.partitions", "2")
-            .orCreate
-    }
+    private val sparkLazy =
+        lazy {
+            SparkSession
+                .builder()
+                .appName("backup-integration")
+                .master("local[2]")
+                .config("spark.ui.enabled", "false")
+                .config("spark.sql.shuffle.partitions", "2")
+                .orCreate
+        }
+    val spark: SparkSession by sparkLazy
 
-    val s3: S3Client by lazy {
-        S3Client
-            .builder()
-            .endpointOverride(URI(minio.s3URL))
-            .region(Region.of(REGION))
-            .forcePathStyle(true)
-            .credentialsProvider(
-                StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(minio.userName, minio.password),
-                ),
-            ).build()
+    private val s3Lazy =
+        lazy {
+            S3Client
+                .builder()
+                .endpointOverride(URI(minio.s3URL))
+                .region(Region.of(REGION))
+                .forcePathStyle(true)
+                .credentialsProvider(
+                    StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(minio.userName, minio.password),
+                    ),
+                ).build()
+        }
+    val s3: S3Client by s3Lazy
+
+    // No hdfs.shutdown(): calling it from a JVM hook races Hadoop's own ShutdownHookManager.
+    init {
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                if (s3Lazy.isInitialized()) runCatching { s3.close() }
+                if (sparkLazy.isInitialized()) runCatching { spark.stop() }
+                if (minioLazy.isInitialized()) runCatching { minio.stop() }
+            },
+        )
     }
 
     fun s3Config(bucket: String): S3Config =

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.Serializable
-import java.net.URI
 import java.nio.file.AccessDeniedException
 
 class FileCopier(
@@ -114,10 +113,11 @@ class FileCopier(
         val sourceConf = HadoopConfigBuilder.build(sourceConfig)
         val targetConf = HadoopConfigBuilder.build(targetConfig)
 
-        return FileSystemFactory.create(sourceConfig, URI(sourceFilePath), sourceConf).use { sourceFs ->
-            FileSystemFactory.create(targetConfig, URI(targetFilePath), targetConf).use { targetFs ->
-                val sourcePath = Path(sourceFilePath)
-                val targetPath = Path(targetFilePath)
+        val sourcePath = Path(sourceFilePath)
+        val targetPath = Path(targetFilePath)
+
+        return FileSystemFactory.create(sourceConfig, sourcePath.toUri(), sourceConf).use { sourceFs ->
+            FileSystemFactory.create(targetConfig, targetPath.toUri(), targetConf).use { targetFs ->
 
                 targetPath.parent?.let { if (!targetFs.exists(it)) targetFs.mkdirs(it) }
 

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/UtilsTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/UtilsTest.kt
@@ -31,7 +31,7 @@ class UtilsTest {
         val redacted = Utils.redactSecrets(config)
 
         val source = redacted.source as S3Config
-        assertEquals("WRONG-bucket", source.bucket) // ponytail: temp break to validate CI report, revert
+        assertEquals("source-bucket", source.bucket) // Non-sensitive preserved
         assertEquals("********", source.accessKey)
         assertEquals("********", source.secretKey)
 

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/UtilsTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/UtilsTest.kt
@@ -31,7 +31,7 @@ class UtilsTest {
         val redacted = Utils.redactSecrets(config)
 
         val source = redacted.source as S3Config
-        assertEquals("source-bucket", source.bucket) // Non-sensitive preserved
+        assertEquals("WRONG-bucket", source.bucket) // ponytail: temp break to validate CI report, revert
         assertEquals("********", source.accessKey)
         assertEquals("********", source.secretKey)
 


### PR DESCRIPTION
### Summary
Stand up an end-to-end integration harness for `iomete-lakehouse-backup` that runs the real backup job against real storage — MinIO (Testcontainers) for S3 and an in-process MiniDFSCluster for HDFS — plus a GitHub Actions gate. 

### Context
The backup job had unit tests only; nothing proved an actual end-to-end copy against real object-store / HDFS semantics, and the subproject had no CI. Regressions could reach `main` unnoticed.

### Implementation
- Suite-wide singletons (one MinIO, one MiniDFSCluster, one `local` Spark), started once and shared; each test uses a fresh bucket / HDFS path for isolation.
- Seed helper (key→bytes map, doubles as expected state) + verify helpers that read the target through the S3 SDK / HDFS client and assert exact key set + byte-for-byte content.
- Three tests via the job's public `BackupJob.run` entry: s3→s3, s3→hdfs, empty-source no-op. Fixture covers nested paths, zero-byte, space/unicode keys, and a 5 MB seeded-random binary.
- Tests live in a dedicated `src/integrationTest` source set (Gradle JVM test suites) so the unshaded Hadoop 3.4.1 + minicluster deps stay off the fast unit-test classpath; Spark's shaded hadoop-client is excluded there (its relocated protobuf breaks MiniDFSCluster). Unit-test Hadoop client pinned to 3.4.1 to match the `iomete/spark` base image.
- Path-filtered CI workflow: JDK 17 + Gradle cache, unit tests then integration tests, on PRs/pushes touching the subproject.
- **Behavior change:** `FileCopier` built a `URI` from a raw path string, so keys containing spaces threw `URISyntaxException`; switched to `Path(...).toUri()`. Real bug surfaced by the harness fixture.
