### PR TITLE
DEL-368 ci(lakehouse-backup): add manual release pipeline with test gating and ACR immutability

### DIFF
--- a/.github/workflows/lakehouse_backup_image.yml
+++ b/.github/workflows/lakehouse_backup_image.yml
@@ -76,6 +76,10 @@ jobs:
             # Main release: immutable version + short-sha tags.
             tag=$(sed -n 's/^projectVersion=//p' gradle.properties)
             sha=$(git rev-parse --short HEAD)
+            if [ -z "$tag" ]; then
+              echo "::error::projectVersion not found in gradle.properties"
+              exit 1
+            fi
             if az acr repository show --name ${{ secrets.ACR_NAME }} --image iomete/iomete-lakehouse-backup:$tag >/dev/null 2>&1; then
               echo "::error::version $tag already published — bump projectVersion in gradle.properties"
               exit 1

--- a/.github/workflows/lakehouse_backup_image.yml
+++ b/.github/workflows/lakehouse_backup_image.yml
@@ -1,0 +1,62 @@
+name: Lakehouse Backup Image
+
+on:
+  workflow_run:
+    workflows: ["Lakehouse Backup Tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    # Only build once the test workflow succeeded (or on manual dispatch).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: iomete-lakehouse-backup
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('iomete-lakehouse-backup/**/*.gradle*', 'iomete-lakehouse-backup/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_ACR_CREDENTIALS }}
+
+      - name: Log in to ACR
+        run: az acr login --name ${{ secrets.ACR_NAME }}
+
+      - name: Build and push image
+        run: make docker-push extra_tag=$(git rev-parse --short HEAD)

--- a/.github/workflows/lakehouse_backup_image.yml
+++ b/.github/workflows/lakehouse_backup_image.yml
@@ -69,8 +69,10 @@ jobs:
         run: az acr login --name ${{ secrets.ACR_NAME }}
 
       - name: Build and push image
+        env:
+          REF: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.ref_name }}" = "main" ]; then
+          if [ "$REF" = "main" ]; then
             # Main release: immutable version + short-sha tags.
             tag=$(sed -n 's/^projectVersion=//p' gradle.properties)
             sha=$(git rev-parse --short HEAD)
@@ -86,6 +88,6 @@ jobs:
             done
           else
             # Branch test build: single mutable branch-name tag.
-            branch_tag=$(echo "${{ github.ref_name }}" | tr '/' '-')
+            branch_tag=$(echo "$REF" | tr '/' '-')
             make docker-push tag="$branch_tag"
           fi

--- a/.github/workflows/lakehouse_backup_image.yml
+++ b/.github/workflows/lakehouse_backup_image.yml
@@ -1,20 +1,32 @@
 name: Lakehouse Backup Image
 
 on:
-  workflow_run:
-    workflows: ["Lakehouse Backup Tests"]
-    types: [completed]
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      skip_tests:
+        description: 'Skip tests (branch builds only; ignored on main)'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
+  tests:
+    # Always run on main; on a branch, honour skip_tests.
+    if: ${{ github.ref_name == 'main' || !inputs.skip_tests }}
+    uses: ./.github/workflows/lakehouse_backup_tests.yml
+    secrets: inherit
+
   build-and-push:
-    # Only build once the test workflow succeeded (or on manual dispatch).
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    needs: tests
+    # Build if tests passed or were legitimately skipped (branch), never if they failed.
+    if: ${{ always() && (needs.tests.result == 'success' || needs.tests.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,8 +37,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -48,10 +58,10 @@ jobs:
         run: chmod +x gradlew
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Azure
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_ACR_CREDENTIALS }}
 
@@ -59,4 +69,23 @@ jobs:
         run: az acr login --name ${{ secrets.ACR_NAME }}
 
       - name: Build and push image
-        run: make docker-push extra_tag=$(git rev-parse --short HEAD)
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            # Main release: immutable version + short-sha tags.
+            tag=$(sed -n 's/^projectVersion=//p' gradle.properties)
+            sha=$(git rev-parse --short HEAD)
+            if az acr repository show --name ${{ secrets.ACR_NAME }} --image iomete/iomete-lakehouse-backup:$tag >/dev/null 2>&1; then
+              echo "::error::version $tag already published — bump projectVersion in gradle.properties"
+              exit 1
+            fi
+            make docker-push-tag extra_tag=$sha
+            for t in "$tag" "$sha"; do
+              az acr repository update --name ${{ secrets.ACR_NAME }} \
+                --image iomete/iomete-lakehouse-backup:$t \
+                --write-enabled false --delete-enabled false
+            done
+          else
+            # Branch test build: single mutable branch-name tag.
+            branch_tag=$(echo "${{ github.ref_name }}" | tr '/' '-')
+            make docker-push tag="$branch_tag"
+          fi

--- a/.github/workflows/lakehouse_backup_release.yml
+++ b/.github/workflows/lakehouse_backup_release.yml
@@ -36,16 +36,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.gradle/caches
@@ -58,10 +58,10 @@ jobs:
         run: chmod +x gradlew
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           creds: ${{ secrets.AZURE_ACR_CREDENTIALS }}
 

--- a/.github/workflows/lakehouse_backup_release.yml
+++ b/.github/workflows/lakehouse_backup_release.yml
@@ -1,4 +1,4 @@
-name: Lakehouse Backup Image
+name: Lakehouse Backup Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/lakehouse_backup_tests.yml
+++ b/.github/workflows/lakehouse_backup_tests.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - 'iomete-lakehouse-backup/**'
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lakehouse_backup_tests.yml
+++ b/.github/workflows/lakehouse_backup_tests.yml
@@ -27,16 +27,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.gradle/caches
@@ -56,14 +56,14 @@ jobs:
 
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
         with:
           report_paths: 'iomete-lakehouse-backup/build/test-results/**/*.xml'
           detailed_summary: true
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-reports
           path: |

--- a/iomete-lakehouse-backup/Makefile
+++ b/iomete-lakehouse-backup/Makefile
@@ -17,9 +17,13 @@ docker-build: build
 
 .PHONY: docker-push
 docker-push: build
-	docker buildx build --platform linux/amd64,linux/arm64 --build-arg SPARK_IMAGE=$(spark_image) -f Dockerfile -t ${image}:${tag} $(if $(extra_tag),-t ${image}:$(extra_tag)) --push . --sbom=true --provenance=true
-	@echo ${image}
-	@echo ${tag} $(extra_tag)
+	docker buildx build --platform linux/amd64,linux/arm64 --build-arg SPARK_IMAGE=$(spark_image) -f Dockerfile -t ${image}:${tag} --push . --sbom=true --provenance=true
+	@echo ${image}:${tag}
+
+.PHONY: docker-push-tag
+docker-push-tag: build
+	docker buildx build --platform linux/amd64,linux/arm64 --build-arg SPARK_IMAGE=$(spark_image) -f Dockerfile -t ${image}:${tag} -t ${image}:$(extra_tag) --push . --sbom=true --provenance=true
+	@echo ${image}:${tag} ${image}:$(extra_tag)
 
 .PHONY: docker-push-latest
 docker-push-latest: build

--- a/iomete-lakehouse-backup/Makefile
+++ b/iomete-lakehouse-backup/Makefile
@@ -1,5 +1,7 @@
 image := iomete.azurecr.io/iomete/iomete-lakehouse-backup
 tag   := $(shell sed -n 's/^projectVersion=//p' gradle.properties)
+# Optional second tag (e.g. commit SHA) for per-build traceability.
+extra_tag :=
 
 spark_version  := $(shell sed -n 's/^sparkVersion=//p' gradle.properties)
 spark_revision := $(shell sed -n 's/^sparkImageRevision=//p' gradle.properties)
@@ -15,9 +17,9 @@ docker-build: build
 
 .PHONY: docker-push
 docker-push: build
-	docker buildx build --platform linux/amd64,linux/arm64 --build-arg SPARK_IMAGE=$(spark_image) -f Dockerfile -t ${image}:${tag} --push . --sbom=true --provenance=true
+	docker buildx build --platform linux/amd64,linux/arm64 --build-arg SPARK_IMAGE=$(spark_image) -f Dockerfile -t ${image}:${tag} $(if $(extra_tag),-t ${image}:$(extra_tag)) --push . --sbom=true --provenance=true
 	@echo ${image}
-	@echo ${tag}
+	@echo ${tag} $(extra_tag)
 
 .PHONY: docker-push-latest
 docker-push-latest: build


### PR DESCRIPTION
Closes DEL-368

# Add lakehouse-backup image release pipeline

## Summary

Adds a manual, test-gated CI pipeline for building and publishing the lakehouse-backup Docker image, with immutable release tags on `main` and mutable, throwaway tags for branch test builds. Previously there was no CI release path — images were built and pushed manually and locally via `make docker-push`.

## Context

`main` had no image/release workflow; publishing was a manual, local step run from a developer machine. That meant no test gating before publish, no distinction between a real `main` release and an ad-hoc branch build, and no immutability guarantees on published version tags.

This branch introduces an explicit, controlled release pipeline:
- Publishing is a deliberate CI action, gated on the tests passing.
- `main` releases are versioned and immutable in ACR, with a fail-fast guard against re-publishing an existing version.
- Branch builds are supported for testing, isolated behind a single mutable tag that never touches release artifacts or `latest`.

## Implementation

**Release workflow (`lakehouse_backup_release.yml`, new)**
- Triggers on `workflow_dispatch` only. Works for `main` and any branch — branch runs are treated as test builds.
- `skip_tests` boolean input lets branch builds skip the test job; on `main`, tests always run (`skip_tests` is ignored).
- Reuses `lakehouse_backup_tests.yml` via `workflow_call` as the single source of truth for tests. The `build-and-push` job runs only if tests passed or were legitimately skipped, never on failure.
- Tag / immutability policy:
  - `main`: pushes `:<projectVersion>` (from `gradle.properties`) + `:<short-sha>`. A pre-check fails fast if the version tag already exists in ACR. Both tags are then locked immutable (`--write-enabled false --delete-enabled false`).
  - Branch: pushes a single mutable `:<branch-name>` tag (`/` → `-`).
  - `latest` is left untouched.

**Test workflow (`lakehouse_backup_tests.yml`)**
- Adds a `workflow_call` trigger so the release workflow can reuse it. Existing push/PR triggers are unchanged.

**Makefile (`iomete-lakehouse-backup/Makefile`)**
- New `docker-push-tag` pushes the version tag plus an `extra_tag` (e.g. commit SHA) for per-build traceability.
