### PR TITLE
feat(lakehouse-backup): atomic copy with length verification

### DIFF
--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/AtomicCopyIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/AtomicCopyIntegrationTest.kt
@@ -1,0 +1,148 @@
+package com.iomete.backup.integration
+
+import com.iomete.backup.BackupJob
+import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.StorageConfig
+import com.iomete.backup.integration.fixtures.assertMatches
+import com.iomete.backup.integration.fixtures.readHdfs
+import com.iomete.backup.integration.fixtures.readS3
+import com.iomete.backup.integration.fixtures.seedS3
+import com.iomete.backup.integration.harness.FaultInjection
+import com.iomete.backup.integration.harness.IntegrationHarness
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.random.Random
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Verify-before-visible under induced mid-copy failure, on both target schemes. Faults are injected
+ * through the `hadoopOptions` seam registering a test-only FileSystem that throws mid-write.
+ */
+class AtomicCopyIntegrationTest {
+    class Target(
+        val config: StorageConfig,
+        val read: () -> Map<String, ByteArray>,
+    )
+
+    interface Scheme {
+        fun target(hadoopOptions: Map<String, String> = emptyMap()): Target
+
+        fun faultOptions(
+            afterBytes: Long,
+            maxFailures: Int,
+            targetName: String? = null,
+        ): Map<String, String>
+    }
+
+    @ParameterizedTest(name = "mid-copy failure on {0} leaves no file at final path and no temp residue")
+    @MethodSource("schemes")
+    fun midCopyFailureLeavesNothing(
+        @Suppress("UNUSED_PARAMETER") name: String,
+        scheme: Scheme,
+    ) {
+        val source = IntegrationHarness.freshBucket()
+        seedS3(source, mapOf("data/part.bin" to Random(7).nextBytes(FILE_SIZE)))
+
+        val target = scheme.target(scheme.faultOptions(afterBytes = FAIL_AT, maxFailures = -1))
+
+        assertFailsWith<IllegalStateException> {
+            BackupJob.run(
+                IntegrationHarness.spark,
+                ApplicationConfig(source = IntegrationHarness.s3Config(source), target = target.config),
+            )
+        }
+
+        assertTrue(target.read().isEmpty(), "a failed copy must leave neither final file nor temp residue")
+    }
+
+    @ParameterizedTest(name = "partial failure on {0} keeps completed files and removes the failed one")
+    @MethodSource("schemes")
+    fun partialFailureKeepsCompletedFiles(
+        @Suppress("UNUSED_PARAMETER") name: String,
+        scheme: Scheme,
+    ) {
+        val source = IntegrationHarness.freshBucket()
+        val completed =
+            mapOf(
+                "data/a.bin" to Random(1).nextBytes(FILE_SIZE),
+                "data/b.bin" to Random(2).nextBytes(FILE_SIZE),
+            )
+        seedS3(source, completed + mapOf("data/c.bin" to Random(3).nextBytes(FILE_SIZE)))
+
+        val target = scheme.target(scheme.faultOptions(afterBytes = FAIL_AT, maxFailures = -1, targetName = "c.bin"))
+
+        assertFailsWith<IllegalStateException> {
+            BackupJob.run(
+                IntegrationHarness.spark,
+                ApplicationConfig(source = IntegrationHarness.s3Config(source), target = target.config),
+            )
+        }
+
+        assertMatches(completed, target.read())
+    }
+
+    @ParameterizedTest(name = "fail-once-then-recover on {0} succeeds within the retry loop")
+    @MethodSource("schemes")
+    fun failOnceThenRecover(
+        @Suppress("UNUSED_PARAMETER") name: String,
+        scheme: Scheme,
+    ) {
+        val source = IntegrationHarness.freshBucket()
+        val payload = Random(9).nextBytes(FILE_SIZE)
+        val tree = mapOf("data/part.bin" to payload)
+        seedS3(source, tree)
+
+        val target = scheme.target(scheme.faultOptions(afterBytes = FAIL_AT, maxFailures = 1))
+
+        BackupJob.run(
+            IntegrationHarness.spark,
+            ApplicationConfig(source = IntegrationHarness.s3Config(source), target = target.config),
+        )
+
+        assertMatches(tree, target.read())
+    }
+
+    companion object {
+        private const val FILE_SIZE = 8192
+        private const val FAIL_AT = 2048L
+
+        private val s3Scheme =
+            object : Scheme {
+                override fun target(hadoopOptions: Map<String, String>): Target {
+                    val bucket = IntegrationHarness.freshBucket()
+                    return Target(
+                        config = IntegrationHarness.s3Config(bucket, hadoopOptions),
+                        read = { readS3(bucket) },
+                    )
+                }
+
+                override fun faultOptions(
+                    afterBytes: Long,
+                    maxFailures: Int,
+                    targetName: String?,
+                ) = FaultInjection.s3Options(afterBytes, maxFailures, targetName)
+            }
+
+        private val hdfsScheme =
+            object : Scheme {
+                override fun target(hadoopOptions: Map<String, String>): Target {
+                    val path = IntegrationHarness.freshHdfsPath()
+                    return Target(
+                        config = IntegrationHarness.hdfsConfig(path, hadoopOptions),
+                        read = { readHdfs(path) },
+                    )
+                }
+
+                override fun faultOptions(
+                    afterBytes: Long,
+                    maxFailures: Int,
+                    targetName: String?,
+                ) = FaultInjection.hdfsOptions(afterBytes, maxFailures, targetName)
+            }
+
+        @JvmStatic
+        fun schemes(): List<Arguments> = listOf(Arguments.of("s3", s3Scheme), Arguments.of("hdfs", hdfsScheme))
+    }
+}

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/AtomicCopyIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/AtomicCopyIntegrationTest.kt
@@ -16,10 +16,7 @@ import kotlin.random.Random
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-/**
- * Verify-before-visible under induced mid-copy failure, on both target schemes. Faults are injected
- * through the `hadoopOptions` seam registering a test-only FileSystem that throws mid-write.
- */
+/** Verify-before-visible under induced mid-copy failure, on both target schemes. */
 class AtomicCopyIntegrationTest {
     class Target(
         val config: StorageConfig,

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/FaultInjection.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/FaultInjection.kt
@@ -14,12 +14,7 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
-/**
- * Config-driven fault injection for integration tests. Registered through the `hadoopOptions` seam
- * (`fs.<scheme>.impl`), each subclass wraps the target temp-file write in a stream that throws after
- * a fixed number of bytes, simulating a mid-copy failure. Failure count is keyed by a per-test id so
- * a test can fail once then recover, or fail forever.
- */
+/** Reaches the job by registering these filesystems as `fs.<scheme>.impl` via the hadoopOptions seam. */
 object FaultInjection {
     const val ID_KEY = "iomete.test.fault.id"
     const val AFTER_BYTES_KEY = "iomete.test.fault.afterBytes"

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/FaultInjection.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/FaultInjection.kt
@@ -1,0 +1,132 @@
+package com.iomete.backup.integration.harness
+
+import com.iomete.backup.copy.TempFiles
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FSDataOutputStream
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.fs.s3a.S3AFileSystem
+import org.apache.hadoop.hdfs.DistributedFileSystem
+import org.apache.hadoop.util.Progressable
+import java.io.IOException
+import java.io.OutputStream
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Config-driven fault injection for integration tests. Registered through the `hadoopOptions` seam
+ * (`fs.<scheme>.impl`), each subclass wraps the target temp-file write in a stream that throws after
+ * a fixed number of bytes, simulating a mid-copy failure. Failure count is keyed by a per-test id so
+ * a test can fail once then recover, or fail forever.
+ */
+object FaultInjection {
+    const val ID_KEY = "iomete.test.fault.id"
+    const val AFTER_BYTES_KEY = "iomete.test.fault.afterBytes"
+    const val MAX_FAILURES_KEY = "iomete.test.fault.maxFailures"
+    const val TARGET_NAME_KEY = "iomete.test.fault.targetName"
+
+    private val counters = ConcurrentHashMap<String, AtomicInteger>()
+
+    fun s3Options(
+        afterBytes: Long,
+        maxFailures: Int,
+        targetName: String? = null,
+        id: String = UUID.randomUUID().toString(),
+    ): Map<String, String> = base(afterBytes, maxFailures, targetName, id) + ("fs.s3a.impl" to FaultyS3AFileSystem::class.java.name)
+
+    fun hdfsOptions(
+        afterBytes: Long,
+        maxFailures: Int,
+        targetName: String? = null,
+        id: String = UUID.randomUUID().toString(),
+    ): Map<String, String> = base(afterBytes, maxFailures, targetName, id) + ("fs.hdfs.impl" to FaultyHdfsFileSystem::class.java.name)
+
+    private fun base(
+        afterBytes: Long,
+        maxFailures: Int,
+        targetName: String?,
+        id: String,
+    ): Map<String, String> =
+        buildMap {
+            put(ID_KEY, id)
+            put(AFTER_BYTES_KEY, afterBytes.toString())
+            put(MAX_FAILURES_KEY, maxFailures.toString())
+            targetName?.let { put(TARGET_NAME_KEY, it) }
+        }
+
+    fun maybeWrap(
+        conf: Configuration,
+        path: Path,
+        out: FSDataOutputStream,
+    ): FSDataOutputStream {
+        val id = conf.get(ID_KEY) ?: return out
+        if (!TempFiles.isTemp(path.name)) return out
+
+        val targetName = conf.get(TARGET_NAME_KEY)
+        if (targetName != null && !path.name.endsWith("-$targetName")) return out
+
+        val maxFailures = conf.getInt(MAX_FAILURES_KEY, -1)
+        val count = counters.getOrPut(id) { AtomicInteger(0) }.incrementAndGet()
+        val shouldFail = maxFailures < 0 || count <= maxFailures
+        if (!shouldFail) return out
+
+        return FSDataOutputStream(FailingOutputStream(out, conf.getLong(AFTER_BYTES_KEY, 0L)), null)
+    }
+}
+
+private class FailingOutputStream(
+    private val delegate: OutputStream,
+    private val afterBytes: Long,
+) : OutputStream() {
+    private var written = 0L
+
+    override fun write(b: Int) {
+        if (written >= afterBytes) throw IOException("injected fault after $afterBytes bytes")
+        delegate.write(b)
+        written++
+    }
+
+    override fun write(
+        b: ByteArray,
+        off: Int,
+        len: Int,
+    ) {
+        val remaining = afterBytes - written
+        if (remaining <= 0) throw IOException("injected fault after $afterBytes bytes")
+        val allowed = minOf(len.toLong(), remaining).toInt()
+        delegate.write(b, off, allowed)
+        written += allowed
+        if (allowed < len) throw IOException("injected fault after $afterBytes bytes")
+    }
+
+    override fun flush() = delegate.flush()
+
+    override fun close() = delegate.close()
+}
+
+class FaultyS3AFileSystem : S3AFileSystem() {
+    override fun create(
+        f: Path,
+        permission: FsPermission,
+        overwrite: Boolean,
+        bufferSize: Int,
+        replication: Short,
+        blockSize: Long,
+        progress: Progressable?,
+    ): FSDataOutputStream =
+        FaultInjection.maybeWrap(conf, f, super.create(f, permission, overwrite, bufferSize, replication, blockSize, progress))
+}
+
+class FaultyHdfsFileSystem : DistributedFileSystem() {
+    override fun create(
+        f: Path,
+        permission: FsPermission,
+        overwrite: Boolean,
+        bufferSize: Int,
+        replication: Short,
+        blockSize: Long,
+        progress: Progressable?,
+    ): FSDataOutputStream =
+        FaultInjection.maybeWrap(conf, f, super.create(f, permission, overwrite, bufferSize, replication, blockSize, progress))
+}

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
@@ -76,7 +76,10 @@ object IntegrationHarness {
         )
     }
 
-    fun s3Config(bucket: String): S3Config =
+    fun s3Config(
+        bucket: String,
+        hadoopOptions: Map<String, String> = emptyMap(),
+    ): S3Config =
         S3Config(
             bucket = bucket,
             endpoint = minio.s3URL,
@@ -84,11 +87,20 @@ object IntegrationHarness {
             accessKey = minio.userName,
             secretKey = minio.password,
             region = REGION,
+            hadoopOptions = hadoopOptions,
         )
 
-    fun hdfsConfig(path: String): HdfsConfig {
+    fun hdfsConfig(
+        path: String,
+        hadoopOptions: Map<String, String> = emptyMap(),
+    ): HdfsConfig {
         val namenode = "localhost:${hdfs.nameNodePort}"
-        return HdfsConfig(namenode = namenode, path = path, user = System.getProperty("user.name"))
+        return HdfsConfig(
+            namenode = namenode,
+            path = path,
+            user = System.getProperty("user.name"),
+            hadoopOptions = hadoopOptions,
+        )
     }
 
     /** A fresh, empty bucket for one test. */

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
@@ -11,6 +11,7 @@ import com.iomete.backup.model.SourceListing
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.net.URI
 
 object BackupJob {
@@ -70,9 +71,13 @@ object BackupJob {
         val targetConf = HadoopConfigBuilder.build(config.target)
         val targetRoot = config.target.rootUri
 
-        FileSystemFactory.create(config.target, URI(targetRoot), targetConf).use { targetFs ->
-            val deleted = TempFiles.sweep(targetFs, Path(targetRoot))
-            if (deleted > 0) logger.info("Start-of-run sweep removed {} orphaned temp file(s)", deleted)
+        try {
+            FileSystemFactory.create(config.target, URI(targetRoot), targetConf).use { targetFs ->
+                val deleted = TempFiles.sweep(targetFs, Path(targetRoot))
+                if (deleted > 0) logger.info("Start-of-run sweep removed {} orphaned temp file(s)", deleted)
+            }
+        } catch (e: IOException) {
+            logger.warn("Start-of-run orphan sweep skipped: could not enumerate target {}", targetRoot, e)
         }
     }
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
@@ -3,7 +3,6 @@ package com.iomete.backup
 import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.copy.CopyJobRunner
-import com.iomete.backup.copy.TempFiles
 import com.iomete.backup.fs.FileLister
 import com.iomete.backup.fs.FileSystemFactory
 import com.iomete.backup.fs.HadoopConfigBuilder
@@ -11,7 +10,6 @@ import com.iomete.backup.model.SourceListing
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
-import java.io.IOException
 import java.net.URI
 
 object BackupJob {
@@ -21,8 +19,6 @@ object BackupJob {
         spark: SparkSession,
         config: ApplicationConfig,
     ) {
-        sweepOrphanTemps(config)
-
         logger.info("Enumerating source files...")
         val (files, emptyDirs) = enumerateSource(config)
 
@@ -63,21 +59,6 @@ object BackupJob {
 
         check(summary.failureCount == 0) {
             "${summary.failureCount} entr${if (summary.failureCount == 1) "y" else "ies"} failed to copy"
-        }
-    }
-
-    // Assumes non-overlapping runs.
-    private fun sweepOrphanTemps(config: ApplicationConfig) {
-        val targetConf = HadoopConfigBuilder.build(config.target)
-        val targetRoot = config.target.rootUri
-
-        try {
-            FileSystemFactory.create(config.target, URI(targetRoot), targetConf).use { targetFs ->
-                val deleted = TempFiles.sweep(targetFs, Path(targetRoot))
-                if (deleted > 0) logger.info("Start-of-run sweep removed {} orphaned temp file(s)", deleted)
-            }
-        } catch (e: IOException) {
-            logger.warn("Start-of-run orphan sweep skipped: could not enumerate target {}", targetRoot, e)
         }
     }
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
@@ -3,6 +3,7 @@ package com.iomete.backup
 import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.copy.CopyJobRunner
+import com.iomete.backup.copy.TempFiles
 import com.iomete.backup.fs.FileLister
 import com.iomete.backup.fs.FileSystemFactory
 import com.iomete.backup.fs.HadoopConfigBuilder
@@ -19,6 +20,8 @@ object BackupJob {
         spark: SparkSession,
         config: ApplicationConfig,
     ) {
+        sweepOrphanTemps(config)
+
         logger.info("Enumerating source files...")
         val (files, emptyDirs) = enumerateSource(config)
 
@@ -59,6 +62,17 @@ object BackupJob {
 
         check(summary.failureCount == 0) {
             "${summary.failureCount} entr${if (summary.failureCount == 1) "y" else "ies"} failed to copy"
+        }
+    }
+
+    // Assumes non-overlapping runs.
+    private fun sweepOrphanTemps(config: ApplicationConfig) {
+        val targetConf = HadoopConfigBuilder.build(config.target)
+        val targetRoot = config.target.rootUri
+
+        FileSystemFactory.create(config.target, URI(targetRoot), targetConf).use { targetFs ->
+            val deleted = TempFiles.sweep(targetFs, Path(targetRoot))
+            if (deleted > 0) logger.info("Start-of-run sweep removed {} orphaned temp file(s)", deleted)
         }
     }
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
@@ -19,6 +19,9 @@ data class ApplicationConfig(
 )
 sealed class StorageConfig : java.io.Serializable {
     abstract val rootUri: String
+
+    // Test seam only: Validator rejects it on the load path, so it is reachable
+    // solely by callers driving BackupJob directly.
     abstract val hadoopOptions: Map<String, String>
 }
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
@@ -19,6 +19,7 @@ data class ApplicationConfig(
 )
 sealed class StorageConfig : java.io.Serializable {
     abstract val rootUri: String
+    abstract val hadoopOptions: Map<String, String>
 }
 
 data class S3Config(
@@ -29,6 +30,7 @@ data class S3Config(
     val accessKey: String,
     val secretKey: String,
     val region: String = "us-east-1",
+    override val hadoopOptions: Map<String, String> = emptyMap(),
 ) : StorageConfig() {
     override val rootUri: String
         get() {
@@ -42,6 +44,7 @@ data class HdfsConfig(
     val path: String = "",
     val authentication: String = "simple",
     val user: String,
+    override val hadoopOptions: Map<String, String> = emptyMap(),
 ) : StorageConfig() {
     override val rootUri: String
         get() {

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
@@ -30,6 +30,10 @@ object Validator {
         location: String,
         errors: MutableList<String>,
     ) {
+        if (storage.hadoopOptions.isNotEmpty()) {
+            errors.add("$location: 'hadoopOptions' is not a supported configuration option")
+        }
+
         when (storage) {
             is S3Config -> validateS3Config(storage, location, errors)
             is HdfsConfig -> validateHdfsConfig(storage, location, errors)

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/CopyJobRunner.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/CopyJobRunner.kt
@@ -4,9 +4,9 @@ import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.copy.internal.FileCopier
 import com.iomete.backup.copy.internal.PathResolver
 import com.iomete.backup.copy.internal.aggregateCopyResults
-import com.iomete.backup.model.FileEntry
 import com.iomete.backup.fs.FileSystemFactory
 import com.iomete.backup.fs.HadoopConfigBuilder
+import com.iomete.backup.model.FileEntry
 import org.apache.hadoop.fs.Path
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.SparkSession

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/TempFiles.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/TempFiles.kt
@@ -1,0 +1,33 @@
+package com.iomete.backup.copy
+
+import com.iomete.backup.fs.FileLister
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.Path
+import org.apache.spark.TaskContext
+import java.util.UUID
+
+object TempFiles {
+    // Dot-prefixed so Hadoop/Spark readers skip temp files.
+    const val PREFIX = ".iomete-backup-tmp-"
+
+    fun pathFor(finalPath: Path): Path {
+        val attemptId = TaskContext.get()?.taskAttemptId()?.toString() ?: UUID.randomUUID().toString()
+        val tempName = "$PREFIX$attemptId-${finalPath.name}"
+        val parent = finalPath.parent
+        return if (parent != null) Path(parent, tempName) else Path(tempName)
+    }
+
+    fun isTemp(name: String): Boolean = name.startsWith(PREFIX)
+
+    fun sweep(
+        fs: FileSystem,
+        root: Path,
+    ): Int {
+        if (!fs.exists(root)) return 0
+
+        return FileLister(fs)
+            .listRecursively(root)
+            .filter { isTemp(Path(it.path).name) }
+            .count { fs.delete(Path(it.path), false) }
+    }
+}

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/TempFiles.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/TempFiles.kt
@@ -1,7 +1,5 @@
 package com.iomete.backup.copy
 
-import com.iomete.backup.fs.FileLister
-import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.Path
 import org.apache.spark.TaskContext
 import java.util.UUID
@@ -18,16 +16,4 @@ object TempFiles {
     }
 
     fun isTemp(name: String): Boolean = name.startsWith(PREFIX)
-
-    fun sweep(
-        fs: FileSystem,
-        root: Path,
-    ): Int {
-        if (!fs.exists(root)) return 0
-
-        return FileLister(fs)
-            .listRecursively(root)
-            .filter { isTemp(Path(it.path).name) }
-            .count { fs.delete(Path(it.path), false) }
-    }
 }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/Backoff.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/Backoff.kt
@@ -1,0 +1,12 @@
+package com.iomete.backup.copy.internal
+
+internal fun fullJitterDelayMs(
+    attempt: Int,
+    baseMs: Long,
+    capMs: Long = 30_000L,
+    rnd: Double = Math.random(),
+): Long {
+    if (baseMs <= 0L || attempt <= 0) return 0L
+    val exp = if (attempt >= 32) capMs else minOf(capMs, baseMs shl attempt)
+    return (rnd.coerceIn(0.0, 1.0) * exp).toLong()
+}

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
@@ -2,8 +2,10 @@ package com.iomete.backup.copy.internal
 
 import com.iomete.backup.config.StorageConfig
 import com.iomete.backup.copy.CopyResult
+import com.iomete.backup.copy.TempFiles
 import com.iomete.backup.fs.FileSystemFactory
 import com.iomete.backup.fs.HadoopConfigBuilder
+import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.FileUtil
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.security.AccessControlException
@@ -88,7 +90,7 @@ class FileCopier(
                 if (isTerminal(e)) break
                 if (attempt < maxAttempts) {
                     try {
-                        Thread.sleep(retryDelayMs)
+                        Thread.sleep(fullJitterDelayMs(attempt, retryDelayMs))
                     } catch (ie: InterruptedException) {
                         Thread.currentThread().interrupt()
                         break
@@ -118,22 +120,49 @@ class FileCopier(
 
         return FileSystemFactory.create(sourceConfig, sourcePath.toUri(), sourceConf).use { sourceFs ->
             FileSystemFactory.create(targetConfig, targetPath.toUri(), targetConf).use { targetFs ->
+                val tempPath = TempFiles.pathFor(targetPath)
 
                 targetPath.parent?.let { if (!targetFs.exists(it)) targetFs.mkdirs(it) }
 
-                val fileSize = sourceFs.getFileStatus(sourcePath).len
-                val copied = FileUtil.copy(sourceFs, sourcePath, targetFs, targetPath, false, true, targetConf)
-                if (!copied) {
-                    throw IOException("FileUtil.copy reported failure: $sourceFilePath -> $targetFilePath")
-                }
+                val sourceLen = sourceFs.getFileStatus(sourcePath).len
 
-                val targetSize = targetFs.getFileStatus(targetPath).len
-                if (targetSize != fileSize) {
-                    throw IOException("Length mismatch: source=$fileSize bytes, target=$targetSize bytes")
-                }
+                try {
+                    val copied = FileUtil.copy(sourceFs, sourcePath, targetFs, tempPath, false, true, targetConf)
 
-                fileSize
+                    if (!copied) {
+                        throw IOException("FileUtil.copy reported failure: $sourceFilePath -> $tempPath")
+                    }
+
+                    val writtenLen = targetFs.getFileStatus(tempPath).len
+                    if (writtenLen != sourceLen) {
+                        throw IOException(
+                            "Length verification failed for $targetFilePath: " +
+                                "source=$sourceLen bytes, written=$writtenLen bytes",
+                        )
+                    }
+
+                    // Overwrite: Hadoop rename returns false on an existing destination.
+                    if (targetFs.exists(targetPath)) targetFs.delete(targetPath, false)
+                    if (!targetFs.rename(tempPath, targetPath)) {
+                        throw IOException("Rename failed: $tempPath -> $targetFilePath")
+                    }
+                    sourceLen
+                } catch (e: Exception) {
+                    deleteQuietly(targetFs, tempPath)
+                    throw e
+                }
             }
+        }
+    }
+
+    private fun deleteQuietly(
+        fs: FileSystem,
+        path: Path,
+    ) {
+        try {
+            fs.delete(path, false)
+        } catch (e: Exception) {
+            log().warn("Best-effort temp cleanup failed for {}: {}", path, e.toString())
         }
     }
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
@@ -141,7 +141,8 @@ class FileCopier(
                         )
                     }
 
-                    // Overwrite: Hadoop rename returns false on an existing destination.
+                    // Overwrite deletes first (rename returns false on an existing destination), so
+                    // targetPath is briefly absent; an atomic swap needs FileContext, and HDFS only.
                     if (targetFs.exists(targetPath)) targetFs.delete(targetPath, false)
                     if (!targetFs.rename(tempPath, targetPath)) {
                         throw IOException("Rename failed: $tempPath -> $targetFilePath")

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/fs/HadoopConfigBuilder.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/fs/HadoopConfigBuilder.kt
@@ -9,7 +9,6 @@ object HadoopConfigBuilder {
     fun build(config: StorageConfig): Configuration {
         val conf = Configuration()
         configMap(config).forEach { (key, value) -> conf[key] = value }
-        // Applied last: overrides any built-in setting.
         config.hadoopOptions.forEach { (key, value) -> conf[key] = value }
         return conf
     }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/fs/HadoopConfigBuilder.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/fs/HadoopConfigBuilder.kt
@@ -9,6 +9,8 @@ object HadoopConfigBuilder {
     fun build(config: StorageConfig): Configuration {
         val conf = Configuration()
         configMap(config).forEach { (key, value) -> conf[key] = value }
+        // Applied last: overrides any built-in setting.
+        config.hadoopOptions.forEach { (key, value) -> conf[key] = value }
         return conf
     }
 

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
@@ -134,6 +134,34 @@ class ValidatorTest {
     }
 
     @Test
+    fun `S3 with hadoopOptions fails validation`() {
+        val config =
+            ApplicationConfig(
+                source = S3Config(bucket = "b", accessKey = "k", secretKey = "s", hadoopOptions = mapOf("fs.s3a.impl" to "x")),
+                target = s3Config(),
+            )
+
+        val result = Validator.validate(config)
+
+        assertIs<ValidationResult.Invalid>(result)
+        assertTrue(result.errors.any { it.contains("hadoopOptions") && it.contains("source") })
+    }
+
+    @Test
+    fun `HDFS with hadoopOptions fails validation`() {
+        val config =
+            ApplicationConfig(
+                source = s3Config(),
+                target = HdfsConfig(namenode = "nn:8020", user = "u", hadoopOptions = mapOf("fs.hdfs.impl" to "x")),
+            )
+
+        val result = Validator.validate(config)
+
+        assertIs<ValidationResult.Invalid>(result)
+        assertTrue(result.errors.any { it.contains("hadoopOptions") && it.contains("target") })
+    }
+
+    @Test
     fun `HDFS with unsupported authentication fails validation`() {
         val config =
             ApplicationConfig(

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/TempFilesTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/TempFilesTest.kt
@@ -1,0 +1,66 @@
+package com.iomete.backup.copy
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.Path
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TempFilesTest {
+    private lateinit var dir: File
+    private lateinit var fs: FileSystem
+
+    @BeforeEach
+    fun setup() {
+        dir = Files.createTempDirectory("temp-file-test").toFile()
+        fs = FileSystem.getLocal(Configuration())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `pathFor produces a temp sibling that preserves parent and final name`() {
+        val temp = TempFiles.pathFor(Path("file:/warehouse/db/part-0001.parquet"))
+
+        assertTrue(TempFiles.isTemp(temp.name))
+        assertTrue(temp.name.endsWith("-part-0001.parquet"))
+        assertEquals(Path("file:/warehouse/db"), temp.parent)
+    }
+
+    @Test
+    fun `isTemp matches only the reserved prefix`() {
+        assertTrue(TempFiles.isTemp("${TempFiles.PREFIX}abc-data.parquet"))
+        assertFalse(TempFiles.isTemp("data.parquet"))
+        assertFalse(TempFiles.isTemp(".other-hidden"))
+    }
+
+    @Test
+    fun `sweep deletes only temp files and returns the count`() {
+        File(dir, "sub").mkdirs()
+        val real = File(dir, "sub/data.parquet").apply { writeText("keep") }
+        val temp1 = File(dir, "sub/${TempFiles.PREFIX}a-data.parquet").apply { writeText("x") }
+        val temp2 = File(dir, "${TempFiles.PREFIX}b-top.parquet").apply { writeText("x") }
+
+        val deleted = TempFiles.sweep(fs, Path(dir.toURI().toString()))
+
+        assertEquals(2, deleted)
+        assertTrue(real.exists())
+        assertFalse(temp1.exists())
+        assertFalse(temp2.exists())
+    }
+
+    @Test
+    fun `sweep on a missing root is a no-op`() {
+        val missing = Path(File(dir, "does-not-exist").toURI().toString())
+        assertEquals(0, TempFiles.sweep(fs, missing))
+    }
+}

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/TempFilesTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/TempFilesTest.kt
@@ -1,32 +1,12 @@
 package com.iomete.backup.copy
 
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.Path
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.io.File
-import java.nio.file.Files
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TempFilesTest {
-    private lateinit var dir: File
-    private lateinit var fs: FileSystem
-
-    @BeforeEach
-    fun setup() {
-        dir = Files.createTempDirectory("temp-file-test").toFile()
-        fs = FileSystem.getLocal(Configuration())
-    }
-
-    @AfterEach
-    fun tearDown() {
-        dir.deleteRecursively()
-    }
-
     @Test
     fun `pathFor produces a temp sibling that preserves parent and final name`() {
         val temp = TempFiles.pathFor(Path("file:/warehouse/db/part-0001.parquet"))
@@ -41,26 +21,5 @@ class TempFilesTest {
         assertTrue(TempFiles.isTemp("${TempFiles.PREFIX}abc-data.parquet"))
         assertFalse(TempFiles.isTemp("data.parquet"))
         assertFalse(TempFiles.isTemp(".other-hidden"))
-    }
-
-    @Test
-    fun `sweep deletes only temp files and returns the count`() {
-        File(dir, "sub").mkdirs()
-        val real = File(dir, "sub/data.parquet").apply { writeText("keep") }
-        val temp1 = File(dir, "sub/${TempFiles.PREFIX}a-data.parquet").apply { writeText("x") }
-        val temp2 = File(dir, "${TempFiles.PREFIX}b-top.parquet").apply { writeText("x") }
-
-        val deleted = TempFiles.sweep(fs, Path(dir.toURI().toString()))
-
-        assertEquals(2, deleted)
-        assertTrue(real.exists())
-        assertFalse(temp1.exists())
-        assertFalse(temp2.exists())
-    }
-
-    @Test
-    fun `sweep on a missing root is a no-op`() {
-        val missing = Path(File(dir, "does-not-exist").toURI().toString())
-        assertEquals(0, TempFiles.sweep(fs, missing))
     }
 }

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/BackoffTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/BackoffTest.kt
@@ -1,0 +1,35 @@
+package com.iomete.backup.copy.internal
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BackoffTest {
+    @Test
+    fun `delay is zero when base is non-positive`() {
+        assertEquals(0L, fullJitterDelayMs(attempt = 5, baseMs = 0L, rnd = 1.0))
+        assertEquals(0L, fullJitterDelayMs(attempt = 5, baseMs = -10L, rnd = 1.0))
+    }
+
+    @Test
+    fun `delay stays within full-jitter bound`() {
+        // bound = min(cap, base * 2^attempt); rnd=1.0 hits the upper edge
+        assertEquals(2000L, fullJitterDelayMs(attempt = 1, baseMs = 1000L, rnd = 1.0))
+        assertEquals(4000L, fullJitterDelayMs(attempt = 2, baseMs = 1000L, rnd = 1.0))
+        assertEquals(0L, fullJitterDelayMs(attempt = 3, baseMs = 1000L, rnd = 0.0))
+    }
+
+    @Test
+    fun `delay is capped`() {
+        // base 1000 * 2^10 = 1_024_000 > cap 30_000
+        assertEquals(30_000L, fullJitterDelayMs(attempt = 10, baseMs = 1000L, capMs = 30_000L, rnd = 1.0))
+    }
+
+    @Test
+    fun `random draws never exceed the bound`() {
+        repeat(1000) {
+            val d = fullJitterDelayMs(attempt = 4, baseMs = 1000L, capMs = 30_000L)
+            assertTrue(d in 0L..16_000L, "delay $d out of bound")
+        }
+    }
+}

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/FileCopierTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/FileCopierTest.kt
@@ -2,11 +2,13 @@ package com.iomete.backup.copy.internal
 
 import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
+import com.iomete.backup.copy.TempFiles
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.apache.hadoop.conf.Configuration
@@ -203,12 +205,14 @@ class FileCopierTest {
             every { FileSystem.newInstance(URI(sourcePathString), any<Configuration>()) } returns sourceFs
             every { FileSystem.newInstance(URI(targetPathString), any<Configuration>()) } returns targetFs
             every { targetFs.exists(any()) } returns true
+            every { targetFs.delete(any(), any()) } returns true
+            every { targetFs.rename(any(), targetPath) } returns true
+            every { targetFs.getFileStatus(any()) } returns FileStatus(42L, false, 1, 1024L, 0L, targetPath)
             every { sourceFs.getFileStatus(sourcePath) } throws
                 java.io.IOException("transient 1") andThenThrows
                 java.io.IOException("transient 2") andThen
                 FileStatus(42L, false, 1, 1024L, 0L, sourcePath)
-            every { FileUtil.copy(sourceFs, sourcePath, targetFs, targetPath, false, true, any()) } returns true
-            every { targetFs.getFileStatus(targetPath) } returns FileStatus(42L, false, 1, 1024L, 0L, targetPath)
+            every { FileUtil.copy(sourceFs, sourcePath, targetFs, any(), false, true, any()) } returns true
             every { sourceFs.close() } just runs
             every { targetFs.close() } just runs
 
@@ -228,58 +232,8 @@ class FileCopierTest {
             assertEquals(3, result.attemptsUsed)
             assertEquals(42L, result.bytesCopied)
             verify(exactly = 3) { sourceFs.getFileStatus(sourcePath) }
-            verify(exactly = 1) { FileUtil.copy(sourceFs, sourcePath, targetFs, targetPath, false, true, any()) }
-        } finally {
-            unmockkStatic(FileUtil::class)
-            unmockkStatic(FileSystem::class)
-        }
-    }
-
-    @Test
-    fun `length mismatch fails the copy after retrying`() {
-        val sourcePathString = "s3a://bucket/in/file.txt"
-        val targetPathString = "hdfs://namenode:8020/out/file.txt"
-        val sourcePath = Path(sourcePathString)
-        val targetPath = Path(targetPathString)
-        val sourceFs = mockk<FileSystem>()
-        val targetFs = mockk<FileSystem>()
-
-        mockkStatic(FileSystem::class)
-        mockkStatic(FileUtil::class)
-        try {
-            every { FileSystem.newInstance(URI(sourcePathString), any<Configuration>()) } returns sourceFs
-            every { FileSystem.newInstance(URI(targetPathString), any<Configuration>(), "backup-user") } returns targetFs
-            every { targetFs.exists(any()) } returns true
-            every { sourceFs.getFileStatus(sourcePath) } returns FileStatus(42L, false, 1, 1024L, 0L, sourcePath)
-            every { FileUtil.copy(sourceFs, sourcePath, targetFs, targetPath, false, true, any()) } returns true
-            every { targetFs.getFileStatus(targetPath) } returns FileStatus(41L, false, 1, 1024L, 0L, targetPath)
-            every { sourceFs.close() } just runs
-            every { targetFs.close() } just runs
-
-            val copier =
-                FileCopier(
-                    sourceConfig = dummyConfig,
-                    targetConfig =
-                        HdfsConfig(
-                            namenode = "namenode:8020",
-                            path = "out",
-                            user = "backup-user",
-                        ),
-                    sourceRoot = "s3a://bucket/in",
-                    targetRoot = "hdfs://namenode:8020/out",
-                    maxAttempts = 3,
-                    retryDelayMs = 0,
-                )
-
-            val result = copier.copySingleFile(sourcePathString)
-
-            assertFalse(result.success)
-            assertEquals(3, result.attemptsUsed)
-            val error = result.error.orEmpty()
-            assertTrue(error.contains("Length mismatch"))
-            assertTrue(error.contains("42"))
-            assertTrue(error.contains("41"))
-            verify(exactly = 3) { targetFs.getFileStatus(targetPath) }
+            verify(exactly = 1) { FileUtil.copy(sourceFs, sourcePath, targetFs, any(), false, true, any()) }
+            verify(exactly = 1) { targetFs.rename(any(), targetPath) }
         } finally {
             unmockkStatic(FileUtil::class)
             unmockkStatic(FileSystem::class)
@@ -457,9 +411,11 @@ class FileCopierTest {
             every { FileSystem.newInstance(URI(sourcePathString), any<Configuration>()) } returns sourceFs
             every { FileSystem.newInstance(URI(targetPathString), any<Configuration>()) } returns targetFs
             every { targetFs.exists(targetParent) } returns true
+            every { targetFs.exists(targetPath) } returns false
+            every { targetFs.rename(any(), targetPath) } returns true
+            every { targetFs.getFileStatus(any()) } returns FileStatus(19L, false, 1, 1024L, 0L, targetPath)
             every { sourceFs.getFileStatus(sourcePath) } returns FileStatus(19L, false, 1, 1024L, 0L, sourcePath)
-            every { FileUtil.copy(sourceFs, sourcePath, targetFs, targetPath, false, true, any()) } returns true
-            every { targetFs.getFileStatus(targetPath) } returns FileStatus(19L, false, 1, 1024L, 0L, targetPath)
+            every { FileUtil.copy(sourceFs, sourcePath, targetFs, any(), false, true, any()) } returns true
             every { sourceFs.close() } just runs
             every { targetFs.close() } just runs
 
@@ -516,9 +472,11 @@ class FileCopierTest {
                 FileSystem.newInstance(URI(targetPathString), any<Configuration>(), "isilon-user")
             } returns targetFs
             every { targetFs.exists(targetParent) } returns true
+            every { targetFs.exists(targetPath) } returns false
+            every { targetFs.rename(any(), targetPath) } returns true
+            every { targetFs.getFileStatus(any()) } returns FileStatus(11L, false, 1, 1024L, 0L, targetPath)
             every { sourceFs.getFileStatus(sourcePath) } returns FileStatus(11L, false, 1, 1024L, 0L, sourcePath)
-            every { FileUtil.copy(sourceFs, sourcePath, targetFs, targetPath, false, true, any()) } returns true
-            every { targetFs.getFileStatus(targetPath) } returns FileStatus(11L, false, 1, 1024L, 0L, targetPath)
+            every { FileUtil.copy(sourceFs, sourcePath, targetFs, any(), false, true, any()) } returns true
             every { sourceFs.close() } just runs
             every { targetFs.close() } just runs
 
@@ -555,5 +513,164 @@ class FileCopierTest {
             unmockkStatic(FileUtil::class)
             unmockkStatic(FileSystem::class)
         }
+    }
+
+    @Test
+    fun `length mismatch deletes temp and fails without renaming`() {
+        val sourcePathString = "s3a://bucket/in/file.txt"
+        val targetPathString = "s3a://bucket/out/file.txt"
+        val sourcePath = Path(sourcePathString)
+        val sourceFs = mockk<FileSystem>()
+        val targetFs = mockk<FileSystem>()
+        val tempSlot = slot<Path>()
+
+        mockkStatic(FileSystem::class)
+        mockkStatic(FileUtil::class)
+        try {
+            every { FileSystem.newInstance(URI(sourcePathString), any<Configuration>()) } returns sourceFs
+            every { FileSystem.newInstance(URI(targetPathString), any<Configuration>()) } returns targetFs
+            every { targetFs.exists(any()) } returns true
+            every { targetFs.delete(any(), any()) } returns true
+            every { sourceFs.getFileStatus(sourcePath) } returns FileStatus(100L, false, 1, 1024L, 0L, sourcePath)
+            every { targetFs.getFileStatus(any()) } returns FileStatus(50L, false, 1, 1024L, 0L, Path(targetPathString))
+            every { FileUtil.copy(sourceFs, sourcePath, targetFs, capture(tempSlot), false, true, any()) } returns true
+            every { sourceFs.close() } just runs
+            every { targetFs.close() } just runs
+
+            val copier =
+                FileCopier(
+                    sourceConfig = dummyConfig,
+                    targetConfig = dummyConfig,
+                    sourceRoot = "s3a://bucket/in",
+                    targetRoot = "s3a://bucket/out",
+                    maxAttempts = 2,
+                    retryDelayMs = 0,
+                )
+
+            val result = copier.copySingleFile(sourcePathString)
+
+            assertFalse(result.success)
+            assertEquals(2, result.attemptsUsed)
+            assertTrue(result.error!!.contains("Length verification failed"))
+            assertTrue(tempSlot.captured.name.startsWith(TempFiles.PREFIX))
+            verify(atLeast = 1) { targetFs.delete(any(), any()) }
+            verify(exactly = 0) { targetFs.rename(any(), any()) }
+        } finally {
+            unmockkStatic(FileUtil::class)
+            unmockkStatic(FileSystem::class)
+        }
+    }
+
+    @Test
+    fun `rename failure deletes temp and fails`() {
+        val sourcePathString = "s3a://bucket/in/file.txt"
+        val targetPathString = "s3a://bucket/out/file.txt"
+        val sourcePath = Path(sourcePathString)
+        val targetPath = Path(targetPathString)
+        val sourceFs = mockk<FileSystem>()
+        val targetFs = mockk<FileSystem>()
+
+        mockkStatic(FileSystem::class)
+        mockkStatic(FileUtil::class)
+        try {
+            every { FileSystem.newInstance(URI(sourcePathString), any<Configuration>()) } returns sourceFs
+            every { FileSystem.newInstance(URI(targetPathString), any<Configuration>()) } returns targetFs
+            every { targetFs.exists(any()) } returns false
+            every { targetFs.mkdirs(any()) } returns true
+            every { targetFs.delete(any(), any()) } returns true
+            every { sourceFs.getFileStatus(sourcePath) } returns FileStatus(11L, false, 1, 1024L, 0L, sourcePath)
+            every { targetFs.getFileStatus(any()) } returns FileStatus(11L, false, 1, 1024L, 0L, targetPath)
+            every { FileUtil.copy(sourceFs, sourcePath, targetFs, any(), false, true, any()) } returns true
+            every { targetFs.rename(any(), targetPath) } returns false
+            every { sourceFs.close() } just runs
+            every { targetFs.close() } just runs
+
+            val copier =
+                FileCopier(
+                    sourceConfig = dummyConfig,
+                    targetConfig = dummyConfig,
+                    sourceRoot = "s3a://bucket/in",
+                    targetRoot = "s3a://bucket/out",
+                    maxAttempts = 1,
+                    retryDelayMs = 0,
+                )
+
+            val result = copier.copySingleFile(sourcePathString)
+
+            assertFalse(result.success)
+            assertTrue(result.error!!.contains("Rename failed"))
+            verify(exactly = 1) { targetFs.delete(any(), any()) }
+        } finally {
+            unmockkStatic(FileUtil::class)
+            unmockkStatic(FileSystem::class)
+        }
+    }
+
+    @Test
+    fun `best-effort temp deletion when copy stream fails mid-write`() {
+        val sourcePathString = "s3a://bucket/in/file.txt"
+        val targetPathString = "s3a://bucket/out/file.txt"
+        val sourcePath = Path(sourcePathString)
+        val sourceFs = mockk<FileSystem>()
+        val targetFs = mockk<FileSystem>()
+
+        mockkStatic(FileSystem::class)
+        mockkStatic(FileUtil::class)
+        try {
+            every { FileSystem.newInstance(URI(sourcePathString), any<Configuration>()) } returns sourceFs
+            every { FileSystem.newInstance(URI(targetPathString), any<Configuration>()) } returns targetFs
+            every { targetFs.exists(any()) } returns true
+            every { targetFs.delete(any(), any()) } returns true
+            every { sourceFs.getFileStatus(sourcePath) } returns FileStatus(11L, false, 1, 1024L, 0L, sourcePath)
+            every { FileUtil.copy(sourceFs, sourcePath, targetFs, any(), false, true, any()) } throws
+                java.io.IOException("mid-stream boom")
+            every { sourceFs.close() } just runs
+            every { targetFs.close() } just runs
+
+            val copier =
+                FileCopier(
+                    sourceConfig = dummyConfig,
+                    targetConfig = dummyConfig,
+                    sourceRoot = "s3a://bucket/in",
+                    targetRoot = "s3a://bucket/out",
+                    maxAttempts = 1,
+                    retryDelayMs = 0,
+                )
+
+            val result = copier.copySingleFile(sourcePathString)
+
+            assertFalse(result.success)
+            verify(exactly = 1) { targetFs.delete(any(), any()) }
+            verify(exactly = 0) { targetFs.rename(any(), any()) }
+        } finally {
+            unmockkStatic(FileUtil::class)
+            unmockkStatic(FileSystem::class)
+        }
+    }
+
+    @Test
+    fun `leaves no temp residue at target after successful copy`() {
+        val sourceFile =
+            File(sourceDir, "data/file.txt").apply {
+                parentFile.mkdirs()
+                writeText("hello world")
+            }
+        val sourceRoot = sourceDir.toURI().toString().trimEnd('/')
+        val targetRoot = targetDir.toURI().toString().trimEnd('/')
+
+        val copier =
+            FileCopier(
+                sourceConfig = dummyConfig,
+                targetConfig = dummyConfig,
+                sourceRoot = sourceRoot,
+                targetRoot = targetRoot,
+            )
+
+        assertTrue(copier.copySingleFile(sourceFile.toURI().toString()).success)
+
+        val residue =
+            File(targetDir, "data").listFiles()?.filter { it.name.startsWith(TempFiles.PREFIX) } ?: emptyList()
+        assertTrue(residue.isEmpty(), "expected no temp residue, found: $residue")
+        assertEquals("hello world", File(targetDir, "data/file.txt").readText())
     }
 }

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/fs/HadoopConfigBuilderTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/fs/HadoopConfigBuilderTest.kt
@@ -103,6 +103,25 @@ class HadoopConfigBuilderTest {
         }
 
         @Test
+        fun `S3 hadoopOptions override built-in settings and add new keys`() {
+            val config =
+                S3Config(
+                    bucket = "my-bucket",
+                    accessKey = "key",
+                    secretKey = "secret",
+                    hadoopOptions =
+                        mapOf(
+                            "fs.s3a.impl.disable.cache" to "false",
+                            "fs.s3a.custom.fault" to "on",
+                        ),
+                )
+            val conf = HadoopConfigBuilder.build(config)
+
+            assertEquals("false", conf.get("fs.s3a.impl.disable.cache"))
+            assertEquals("on", conf.get("fs.s3a.custom.fault"))
+        }
+
+        @Test
         fun `same bucket S3 configs keep credentials isolated in separate configurations`() {
             val sourceConf =
                 HadoopConfigBuilder.build(
@@ -147,6 +166,24 @@ class HadoopConfigBuilderTest {
 
             assertEquals("hdfs://isilon.example.com:8020", conf.get("fs.defaultFS"))
             assertEquals("simple", conf.get("hadoop.security.authentication"))
+        }
+
+        @Test
+        fun `HDFS hadoopOptions override built-in settings and add new keys`() {
+            val config =
+                HdfsConfig(
+                    namenode = "isilon.example.com:8020",
+                    user = "isilon-user",
+                    hadoopOptions =
+                        mapOf(
+                            "hadoop.security.authentication" to "kerberos",
+                            "fs.hdfs.custom.fault" to "on",
+                        ),
+                )
+            val conf = HadoopConfigBuilder.build(config)
+
+            assertEquals("kerberos", conf.get("hadoop.security.authentication"))
+            assertEquals("on", conf.get("fs.hdfs.custom.fault"))
         }
 
         @Test


### PR DESCRIPTION
## Summary

Makes file copy atomic and self-verifying: each file is written to a temporary sibling, its length is checked against the source, and only then is it renamed into its final path. A partially written or corrupt file can no longer become visible at the destination. Retry backoff is changed from a fixed delay to capped exponential backoff with full jitter, and a new integration test exercises the whole path against real MinIO and HDFS targets with faults injected mid-write.

## Context

The previous implementation copied straight to the final target path and only compared lengths afterwards. If the process died mid-copy, or the JVM was killed between the write and the length check, the destination was left holding a truncated file that looked like a legitimate backup. A later restore would silently read corrupt data. The length check itself was also of limited value, since by the time it ran the bad file was already published.

The retry path had a second, smaller problem: every attempt slept for exactly the same interval, so a whole stage worth of tasks failing on a throttled endpoint would retry in lockstep and re-trigger the same throttling.

## Implementation

`FileCopier` now resolves a temp path through the new `TempFiles` object before copying. The temp name is dot-prefixed (`.iomete-backup-tmp-`) so Hadoop and Spark readers skip it, and carries the Spark task attempt id (falling back to a random UUID outside a task context) so concurrent attempts at the same target cannot collide. The copy writes to that temp path, the written length is compared with the source length, and the file is renamed into place only after verification passes. Because Hadoop's `rename` returns `false` when the destination exists, an existing target is deleted immediately before the rename to preserve overwrite semantics. Any failure along the way triggers a best-effort delete of the temp file, logged rather than thrown so the original error is what surfaces.

`Backoff.fullJitterDelayMs` replaces the flat `Thread.sleep(retryDelayMs)`. The delay is drawn uniformly from `[0, min(cap, base << attempt))` with a 30 second cap, which spreads retries across tasks instead of synchronising them. The shift is guarded against overflow for large attempt counts, and a non-positive base still yields no delay.

Fault injection needed a way to substitute a failing `FileSystem` implementation without a production-visible knob. `StorageConfig` gains a `hadoopOptions` map that `HadoopConfigBuilder` applies last, after all built-in settings, so it can both override and extend them. To keep this strictly a test seam, `Validator` rejects any configuration that populates `hadoopOptions`, meaning it can never be set from a user-supplied job config while remaining available to code constructing configs programmatically.

The new `AtomicCopyIntegrationTest` uses that seam to register `FaultyS3AFileSystem` and `FaultyHdfsFileSystem` via `fs.s3a.impl` / `fs.hdfs.impl`. Both subclass the real filesystem and wrap `create` for temp paths only, returning a stream that throws after a configured byte count. Failure counts are keyed by a per-test id, so a scenario can fail once and then recover, fail forever, or target a single named file. Three scenarios run parameterized over both S3 and HDFS targets: a mid-copy failure must leave neither a final file nor temp residue; a failure on one file out of several must leave the completed files intact and the failed one absent; and a fail-once-then-recover run must succeed within the retry loop with byte-identical output.

An orphan temp sweep at the start of each run was prototyped and then dropped. Cleanup on the failure path plus the reserved dot-prefix already keep stale temp files invisible to readers, and a start-of-run sweep across the whole target tree added a full listing cost and a race with concurrent runs for no practical gain.

Unit coverage was extended alongside: `FileCopierTest` asserts temp deletion and absence of rename on length mismatch, rename failure, and mid-write stream failure, plus no temp residue after a successful copy; `TempFilesTest` covers temp path construction and prefix matching; `BackoffTest` covers the jitter bound, cap, and non-positive base; `ValidatorTest` and `HadoopConfigBuilderTest` cover the `hadoopOptions` rejection and override behaviour.
