### PR TITLE
feat(lakehouse-backup): byte-balanced partitioning (DEL-362)

### DIFF
--- a/iomete-lakehouse-backup/README.md
+++ b/iomete-lakehouse-backup/README.md
@@ -74,6 +74,27 @@ adding a `copy` block — no need to delete the target:
 }
 ```
 
+### Tuning how the work is split (advanced)
+
+The job divides the files into units of work of about 1 GB and copies them in
+parallel. The defaults suit most backups, so skip this section unless your run
+matches one of the cases below.
+
+```json
+{
+  "copy": { "bytesPerTask": 1073741824, "filesPerTask": 1000 }
+}
+```
+
+| Field | Default | Lower it when |
+|---|---|---|
+| `bytesPerTask` | `1073741824` (1 GB) | Your backup is a few large files and most of the cluster sits idle. Avoid going below 100 MB, as very small units cost more than they save. |
+| `filesPerTask` | `1000` | Your backup is hundreds of thousands of small files and tasks are slow despite copying little data. Try `250`. |
+
+A file larger than `bytesPerTask` is copied by a single executor and is never
+split, so a run can never finish faster than its largest file. The job logs that
+file's size when it starts.
+
 ### HDFS source or target (any HDFS-compatible storage, e.g. Dell Isilon / OneFS)
 
 Use `type: "hdfs"` for either side of a backup or restore. To back up into an

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
@@ -14,6 +14,10 @@ data class CopyConfig(
     // Only treat a target copy as identical when it is newer than the source by this margin: the
     // two clocks are independent and S3 truncates to whole seconds.
     val clockSkewToleranceMs: Long = 30_000,
+    val bytesPerTask: Long = 1024L * 1024 * 1024,
+    // A byte target alone does not bound task cost: every file pays a fresh filesystem build, so a
+    // batch of tiny files runs long while staying far below the byte target.
+    val filesPerTask: Int = 1000,
 )
 
 @JsonTypeInfo(

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
@@ -13,7 +13,7 @@ data class CopyConfig(
     val skipIdentical: Boolean = true,
     // Only treat a target copy as identical when it is newer than the source by this margin: the
     // two clocks are independent and S3 truncates to whole seconds.
-    val clockSkewToleranceMs: Long = 30_000,
+    val clockSkewToleranceMs: Long = 30L * 1000,
     val bytesPerTask: Long = 1024L * 1024 * 1024,
     // A byte target alone does not bound task cost: every file pays a fresh filesystem build, so a
     // batch of tiny files runs long while staying far below the byte target.

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/CopyJobRunner.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/CopyJobRunner.kt
@@ -64,7 +64,9 @@ object CopyJobRunner {
                 CopyAggregate()
             } else {
                 val rdd = jsc.parallelize(batches, batches.size)
-                aggregateCopyResults(rdd.flatMap { batch -> batch.map { copier.copySingleFile(it) }.iterator() })
+                aggregateCopyResults(
+                    rdd.flatMap { batch -> batch.asSequence().map { copier.copySingleFile(it) }.iterator() },
+                )
             }
         val directoryResults = createDirectories(config, sourceRoot, targetRoot, emptyDirectories)
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/CopyJobRunner.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/CopyJobRunner.kt
@@ -1,9 +1,11 @@
 package com.iomete.backup.copy
 
 import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.copy.internal.CopyAggregate
 import com.iomete.backup.copy.internal.FileCopier
 import com.iomete.backup.copy.internal.PathResolver
 import com.iomete.backup.copy.internal.aggregateCopyResults
+import com.iomete.backup.copy.internal.batchFiles
 import com.iomete.backup.copy.internal.listTargetWithRetries
 import com.iomete.backup.copy.internal.planCopy
 import com.iomete.backup.fs.useFileLister
@@ -54,14 +56,16 @@ object CopyJobRunner {
         logger.info("Skipping {} files already at the target ({} bytes)", plan.skipped.size, skippedBytes)
         plan.skipped.forEach { logger.debug("Skipped, already at target: {}", it.path) }
 
-        val filePaths = plan.toCopy.map { it.path }
-        // Interim: one partition per executor core (Spark default parallelism).
-        // Byte-balanced partitioning will come later.
-        val rdd = jsc.parallelize(filePaths, jsc.defaultParallelism())
+        val batches = batchFiles(plan.toCopy, config.copy.bytesPerTask, config.copy.filesPerTask)
+        logCopyPlan(plan.toCopy, batches.size, config.copy.bytesPerTask)
 
-        logger.info("Copying {} files across {} partitions", filePaths.size, rdd.getNumPartitions())
-
-        val fileResults = aggregateCopyResults(rdd.map { path -> copier.copySingleFile(path) })
+        val fileResults =
+            if (batches.isEmpty()) {
+                CopyAggregate()
+            } else {
+                val rdd = jsc.parallelize(batches, batches.size)
+                aggregateCopyResults(rdd.flatMap { batch -> batch.map { copier.copySingleFile(it) }.iterator() })
+            }
         val directoryResults = createDirectories(config, sourceRoot, targetRoot, emptyDirectories)
 
         val aggregate = directoryResults.fold(fileResults) { acc, result -> acc.add(result) }
@@ -87,6 +91,25 @@ object CopyJobRunner {
         return CopyJobResult(
             summary = summary,
             failedResults = aggregate.failures,
+        )
+    }
+
+    private fun logCopyPlan(
+        toCopy: List<FileEntry>,
+        batchCount: Int,
+        bytesPerTask: Long,
+    ) {
+        val largest = toCopy.maxOfOrNull { it.size } ?: 0
+        val oversized = toCopy.count { it.size > bytesPerTask }
+
+        logger.info(
+            "Copying {} files ({} bytes) across {} tasks; largest single file {} bytes, {} files above the {} byte target",
+            toCopy.size,
+            toCopy.sumOf { it.size },
+            batchCount,
+            largest,
+            oversized,
+            bytesPerTask,
         )
     }
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/CopyBatcher.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/CopyBatcher.kt
@@ -1,0 +1,29 @@
+package com.iomete.backup.copy.internal
+
+import com.iomete.backup.model.FileEntry
+
+// Largest first: Spark launches tasks roughly in partition order, so the longest tasks start first
+// and the cheap ones overlap them.
+internal fun batchFiles(
+    files: List<FileEntry>,
+    bytesPerTask: Long,
+    filesPerTask: Int,
+): List<List<String>> {
+    val batches = mutableListOf<List<String>>()
+    var current = mutableListOf<String>()
+    var currentBytes = 0L
+
+    for (file in files.sortedByDescending { it.size }) {
+        // Limits bind only on a non-empty batch, so a file above the byte target gets a batch to itself.
+        if (current.isNotEmpty() && (currentBytes + file.size > bytesPerTask || current.size >= filesPerTask)) {
+            batches += current
+            current = mutableListOf()
+            currentBytes = 0
+        }
+        current += file.path
+        currentBytes += file.size
+    }
+    if (current.isNotEmpty()) batches += current
+
+    return batches
+}

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/CopyBatcherTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/CopyBatcherTest.kt
@@ -1,0 +1,52 @@
+package com.iomete.backup.copy.internal
+
+import com.iomete.backup.model.FileEntry
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class CopyBatcherTest {
+    private fun file(
+        name: String,
+        size: Long,
+    ) = FileEntry("hdfs://namenode:8020/warehouse/$name", size, 1_000_000)
+
+    private fun batch(
+        files: List<FileEntry>,
+        bytesPerTask: Long = 1000,
+        filesPerTask: Int = 1000,
+    ) = batchFiles(files, bytesPerTask, filesPerTask).map { batch -> batch.map { it.substringAfterLast('/') } }
+
+    @Test
+    fun `a batch is closed before the byte target is exceeded`() {
+        val result = batch(listOf(file("a", 600), file("b", 500)), bytesPerTask = 1000)
+
+        assertEquals(listOf(listOf("a"), listOf("b")), result)
+    }
+
+    @Test
+    fun `the file limit closes a batch far below the byte target`() {
+        val result = batch(List(5) { file("f$it", 1) }, bytesPerTask = 1000, filesPerTask = 2)
+
+        assertEquals(3, result.size)
+        assertEquals(listOf(2, 2, 1), result.map { it.size })
+    }
+
+    @Test
+    fun `a file larger than the byte target gets a batch to itself`() {
+        val result = batch(listOf(file("huge", 5000), file("small", 10)), bytesPerTask = 1000)
+
+        assertEquals(listOf(listOf("huge"), listOf("small")), result)
+    }
+
+    @Test
+    fun `batches are emitted largest first`() {
+        val result = batch(listOf(file("small", 100), file("huge", 900), file("mid", 400)), bytesPerTask = 500)
+
+        assertEquals(listOf(listOf("huge"), listOf("mid", "small")), result)
+    }
+
+    @Test
+    fun `empty input yields no batches`() {
+        assertEquals(emptyList(), batch(emptyList()))
+    }
+}


### PR DESCRIPTION
### Summary
Replace count-based partitioning with byte-balanced batching in `iomete-lakehouse-backup`, so a single large file no longer holds the whole job open while the rest of the cluster idles. Partition count now derives from the work (total bytes / file count), not from `defaultParallelism`.

Closes [DEL-362](https://linear.app/iomete/issue/DEL-362/byte-balanced-partitioning-to-remove-large-file-stragglers).

### Context
Work was distributed with `jsc.parallelize(filePaths, jsc.defaultParallelism())`, which slices the path list into equal-*count* contiguous chunks. Copy cost is proportional to *bytes*: every byte streams through the executor JVM via `FileUtil.copy`, since no server-side copy exists between two different filesystems. A slice holding one huge file ran for minutes while its siblings finished in seconds. The source listing is a recursive directory walk, so large files from the same table directory sit at adjacent indices and land in the *same* slice, concentrating the cost further. Separately, `defaultParallelism` is read at RDD-creation time when only the initial executors exist, so a job creating exactly as many partitions as it has cores never builds a pending-task backlog and never triggers dynamic-allocation scale-out.

### Implementation
- New `copy/internal/CopyBatcher.kt`: pure `batchFiles(files, bytesPerTask, filesPerTask)` sorts by size descending, then greedy next-fit packing. The open batch closes when the next file would breach either the byte target or the file count. Takes `FileEntry` (needs sizes), returns paths only; sizes are driver-side planning data and would fatten every task closure.
- Descending sort does two jobs: bounds wasted batch capacity, and fixes launch order. Spark launches tasks roughly in partition-index order, so the most expensive batches start first (longest-processing-time-first for free). Without it the cluster drains cheap batches and then starts a multi-minute task at the very end.
- Limits bind only on a non-empty batch, so a file above `bytesPerTask` gets a batch to itself instead of being dropped. Files are never split: that needs ranged reads plus multipart assembly, which breaks the existing write-to-temp / verify-length / rename atomic-copy contract. Out of scope here.
- `CopyJobRunner` now uses `parallelize(batches, batches.size)` + `flatMap`. No ceiling from initial cluster size, and deliberately no floor either. No custom `Partitioner` and no shuffle: `partitionBy` would spill every path to shuffle files and fetch them back to rebuild a grouping the driver already holds in memory.
- Empty-plan guard: on an unchanged re-run every file is skipped, so there are no batches, and `parallelize` with a slice count of 0 throws (Spark requires a positive partition count). The runner short-circuits to `CopyAggregate()` and submits no Spark job, while still replicating empty directories and reporting skipped count/bytes. The pre-existing early return did not cover this, since it tests the source listing, which is non-empty on a re-run.
- `logCopyPlan` logs file count, total bytes, batch count, largest single file, and how many files exceed the byte target, making the run's lower bound visible without the Spark UI. Also the measurement that decides whether file splitting is ever worth building.
- Config: `CopyConfig.bytesPerTask` (default 1 GB) and `filesPerTask` (default 1000), documented in the module README under "Tuning how the work is split (advanced)". The two limits are not redundant: task cost is roughly `bytes/bandwidth + files x per_file_overhead`, and the byte limit bounds only the first term. Per-file overhead is high today because `FileCopier.copyOnce` builds both Hadoop configs and both filesystems per file with the filesystem cache disabled, so each file pays for a fresh client and cold connection pool. The `1000` default is sized against that and should be revisited once DEL-359 (per-task filesystem cache) lands.
- Minor: `clockSkewToleranceMs` rewritten as `30L * 1000` to match the `bytesPerTask` product style.
- `CopyBatcherTest` covers byte-target closure, file-limit closure below the byte target, oversized file isolation, largest-first emission, and empty input. Largest-first is the case that matters most: dropping the sort changes no output and raises no error, it only costs wall time, so it would regress silently. Full unit suite and all 19 integration tests pass against real MinIO and MiniDFS; the existing unchanged-re-run integration test already exercises the empty-plan path for s3-to-s3 and s3-to-hdfs and needed no change.
