### PR TITLE
chore: add repo maintenance workflow

### DIFF
--- a/.github/workflows/repo-maintenance.yml
+++ b/.github/workflows/repo-maintenance.yml
@@ -1,0 +1,15 @@
+name: Repo maintenance
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    uses: iomete/infra/.github/workflows/repo-maintenance.yml@main


### PR DESCRIPTION
- Adds a scheduled job that flags pull requests with no activity for 30 days and closes them a week later if nothing changes.
- Any comment, push, or review resets the clock, and a closed pull request keeps its history and can be reopened in one click.
- Add the `keep-open` label to any pull request that should be skipped entirely.
- Only pull requests are affected. Issues are left alone.
- Behaviour is shared across repositories from one central place, so the settings are the same everywhere and only need changing once.
- Background: [Repo Maintenance: Automated Stale PR Handling](https://iomete.atlassian.net/wiki/spaces/IP/pages/837779460/Repo+Maintenance+Automated+Stale+PR+Handling)
- Ticket: [PLA-735](https://linear.app/iomete/issue/PLA-735/roll-out-automated-stale-pr-handling-to-more-repositories)
