### PR TITLE
fix(ci): use a literal concurrency group in the reusable tests workflow

### DIFF
--- a/.github/workflows/lakehouse_backup_tests.yml
+++ b/.github/workflows/lakehouse_backup_tests.yml
@@ -12,7 +12,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: lakehouse-backup-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Replaces `${{ github.workflow }}` with a literal prefix in the concurrency group of `lakehouse_backup_tests.yml`, so that the Lakehouse Backup Release workflow no longer deadlocks against the reusable tests workflow it calls.

## Context

`Lakehouse Backup Release` starts with a `tests` job that delegates to `./.github/workflows/lakehouse_backup_tests.yml` via `workflow_call`. Both workflows declared their concurrency group as `${{ github.workflow }}-${{ github.ref }}`.

Inside a reusable workflow, `github.workflow` resolves to the *calling* workflow's name rather than the callee's. As a result, the release run and the tests run it invoked both computed the same group, `Lakehouse Backup Release-refs/heads/main`. The parent run holds that slot until it finishes, but it cannot finish until the child completes, and the child cannot start until the slot is free. GitHub detects the cycle and aborts the run:

> Canceling since a deadlock was detected for concurrency group: 'Lakehouse Backup Release-refs/heads/main' between a top level workflow and 'tests'

This is what happened on [run 30908309354](https://github.com/iomete/iomete-marketplace-jobs/actions/runs/30908309354), where the release workflow was cancelled before performing any work.

## Implementation

```diff
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: lakehouse-backup-tests-${{ github.ref }}
   cancel-in-progress: true
```

The fix lands on the callee rather than renaming the caller's group, because `github.workflow` is simply the wrong expression to evaluate inside a reusable workflow. A literal group name is stable no matter which workflow calls it, so any future caller cannot reintroduce the same collision. The tests workflow retains its own `cancel-in-progress` deduplication for the standalone push and pull request runs that remain its primary trigger.
