### PR TITLE
feat(lakehouse-backup): per-run stats tables for backup run tracking (DEL-369)

### DIFF
--- a/iomete-lakehouse-backup/README.md
+++ b/iomete-lakehouse-backup/README.md
@@ -183,7 +183,7 @@ values below are the defaults:
 | Field | Default | Description |
 |---|---|---|
 | `enabled` | `true` | Set to `false` to record nothing. |
-| `database` | `spark_catalog.iomete_system_db` | Catalog and database holding both tables. Must be a dotted identifier. The table names cannot be changed. |
+| `database` | `spark_catalog.iomete_system_db` | Database holding both tables, optionally catalog-qualified. The table names cannot be changed. |
 | `maxFailureRows` | `1000` | Maximum failure rows recorded per run. Set to `0` to record none. The `files_failed` count on the run row is unaffected. |
 
 If a write to these tables fails, the job logs a warning and the backup

--- a/iomete-lakehouse-backup/README.md
+++ b/iomete-lakehouse-backup/README.md
@@ -151,6 +151,45 @@ A few things worth knowing before you settle on a number:
   an hour at full speed will take roughly two hours at half of it, and the
   instance stays busy for all of that time.
 
+### Run history
+
+Every run is recorded in two Iceberg tables under
+`spark_catalog.iomete_system_db`:
+
+| Table | Contents |
+|---|---|
+| `lakehouse_backup_runs` | One row per run: status, counts, byte totals, stage timings and the settings the run used. |
+| `lakehouse_backup_run_file_failures` | One row per entry the run failed to copy, joined to the run by `run_id`. |
+
+Recording is enabled by default and needs no configuration. The tables are
+created on the first run. Use them to check whether a scheduled backup
+succeeded, find the files it could not copy, and compare a run against earlier
+ones. See [docs/run-stats.md](docs/run-stats.md) for the full column reference
+and example queries.
+
+To turn recording off or to store the tables elsewhere, add a `stats` block. The
+values below are the defaults:
+
+```json
+{
+  "stats": {
+    "enabled": true,
+    "database": "spark_catalog.iomete_system_db",
+    "maxFailureRows": 1000
+  }
+}
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `true` | Set to `false` to record nothing. |
+| `database` | `spark_catalog.iomete_system_db` | Catalog and database holding both tables. Must be a dotted identifier. The table names cannot be changed. |
+| `maxFailureRows` | `1000` | Maximum failure rows recorded per run. Set to `0` to record none. The `files_failed` count on the run row is unaffected. |
+
+If a write to these tables fails, the job logs a warning and the backup
+continues. A run that copies its data successfully is never failed by a problem
+recording its own history.
+
 ### HDFS source or target (any HDFS-compatible storage, e.g. Dell Isilon / OneFS)
 
 Use `type: "hdfs"` for either side of a backup or restore. To back up into an

--- a/iomete-lakehouse-backup/build.gradle.kts
+++ b/iomete-lakehouse-backup/build.gradle.kts
@@ -12,6 +12,7 @@ version = property("projectVersion") as String
 
 val sparkVersion = property("sparkVersion") as String
 val hadoopAwsVersion = property("hadoopAwsVersion") as String
+val icebergVersion = property("icebergVersion") as String
 
 // Spark on JDK 17 needs these JVM module openings (driver + local executors in tests).
 val sparkJvmArgs =
@@ -55,6 +56,7 @@ testing {
                 implementation("org.apache.hadoop:hadoop-client:$hadoopAwsVersion")
                 implementation("org.apache.hadoop:hadoop-aws:$hadoopAwsVersion")
                 implementation("org.apache.hadoop:hadoop-minicluster:$hadoopAwsVersion")
+                implementation("org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:$icebergVersion")
                 runtimeOnly("org.mockito:mockito-core:5.23.0") // MiniDFSCluster uses Mockito internally
                 implementation("org.testcontainers:junit-jupiter:1.21.4")
                 implementation("org.testcontainers:minio:1.21.4")

--- a/iomete-lakehouse-backup/docs/run-stats.md
+++ b/iomete-lakehouse-backup/docs/run-stats.md
@@ -1,0 +1,248 @@
+# Backup run history
+
+Every run of the backup job is recorded in two Iceberg tables: what it copied,
+how it ended, and how long each stage took. Driver logs are removed with the
+pod, so these tables are usually the only record of a run that is still
+available days later.
+
+Recording is enabled by default and needs no configuration. To turn it off, move
+the tables to another database, or change how many failure rows a run records,
+see the `stats` block in the [README](../README.md#run-history).
+
+## Tables
+
+Both tables are created on first use in `spark_catalog.iomete_system_db`, or in
+the database set by `stats.database`. Both are partitioned by day on
+`started_at`.
+
+| Table | Contents |
+|---|---|
+| `lakehouse_backup_runs` | One row per run: status, counts, byte totals, stage timings and the settings the run used. |
+| `lakehouse_backup_run_file_failures` | One row per entry the run failed to copy, joined to the run by `run_id`. |
+
+The run row is written when the run starts, with `status = 'RUNNING'`, and
+updated when the run ends with the final status, counts and timings. Only the
+driver updates this row. A run still marked `RUNNING` long after `started_at`
+therefore means the driver stopped before it could record the outcome, for
+example because the pod was killed, ran out of memory, or lost its node.
+
+Every column has a comment, so `DESCRIBE TABLE EXTENDED
+spark_catalog.iomete_system_db.lakehouse_backup_runs` returns the same
+descriptions listed below.
+
+## Column reference
+
+### Identity
+
+| Column | Description |
+|---|---|
+| `run_id` | Run ID shown in the IOMETE console. |
+| `job_id` | Identifies the job; the same value for every run of that job. |
+| `started_by` | User who triggered the run. Null for scheduled runs. |
+| `source_type`, `target_type` | `s3` or `hdfs`. |
+| `source_uri`, `target_uri` | Root URIs the run read from and wrote to. |
+
+### Outcome
+
+| Column | Description |
+|---|---|
+| `status` | `RUNNING`, `SUCCEEDED` or `FAILED`. |
+| `error_message` | Exception class and message. Null unless the status is `FAILED`. |
+| `started_at` | When the run started, before source enumeration. |
+| `ended_at` | When the run finished. Null while `RUNNING`. |
+
+### Counts
+
+| Column | Description |
+|---|---|
+| `files_listed` | Files found by source enumeration. |
+| `dirs_listed` | Empty directories found. HDFS sources only. |
+| `files_copied` | Files written to the target. |
+| `files_skipped` | Files already identical at the target. |
+| `files_failed` | Number of entries that failed. Always the true count, even when the failures table holds fewer rows. |
+| `dirs_created` | Empty directories recreated at the target. |
+| `retries_used` | Copy attempts beyond the first, summed across all entries. |
+| `failures_truncated` | True when the failures table holds fewer rows than `files_failed`. |
+| `bytes_source` | Total size of everything enumerated at the source. |
+| `bytes_copied` | Bytes written to the target. |
+| `bytes_skipped` | Bytes in files that were skipped. |
+
+### Stage timings
+
+The five stages run one after another on the driver, so they add up to close to
+the run's wall time. The remainder is mostly the row written when the run
+starts, plus table creation on the first run.
+
+| Column | Description |
+|---|---|
+| `source_listing_ms` | Enumerating the source tree. |
+| `target_listing_ms` | Enumerating the target tree. `0` when `copy.skipIdentical` is `false`. |
+| `planning_ms` | Deciding what to copy and what to skip. |
+| `copy_ms` | Wall time of the distributed copy. The only stage that runs on the cluster. |
+| `dir_create_ms` | Recreating empty directories. |
+
+### Executor timings
+
+These cover the copy stage only and are summed across all tasks, so they are
+much larger than `copy_ms`. Compare them with each other rather than with wall
+time.
+
+| Column | Description |
+|---|---|
+| `copy_task_ms` | Time spent copying files, summed across tasks. |
+| `fs_init_ms` | Building a filesystem client for each file. |
+| `source_read_ms` | Reading from the source. |
+| `target_write_ms` | Writing to the target, including the final upload. |
+| `throttle_wait_ms` | Blocked by the bandwidth limit. |
+| `verify_ms` | Length check after each write. |
+| `commit_ms` | Delete and rename that publish each file. |
+| `retry_sleep_ms` | Waiting between copy attempts. |
+
+Spark can retry or speculate a task, so these timings may count the same work
+more than once. Use them to compare where time went, and use `files_copied` and
+`bytes_copied` for exact totals.
+
+### Settings and shape
+
+| Column | Description |
+|---|---|
+| `bytes_per_task`, `files_per_task`, `skip_identical`, `max_bandwidth_mb_per_sec` | The `copy` settings this run used. `max_bandwidth_mb_per_sec` is null when no limit was set. |
+| `task_count` | Number of Spark tasks the copy was split into. |
+| `largest_file_bytes` | Size of the largest file copied. A single file is never split across tasks, so no run finishes faster than its largest file. |
+
+### Failure rows
+
+| Column | Description |
+|---|---|
+| `run_id` | Joins to `lakehouse_backup_runs.run_id`. |
+| `started_at` | Copied from the run row so both tables share a partition key. |
+| `source_path` | Entry that failed to copy. |
+| `target_path` | Where it would have been written. |
+| `attempts_used` | Copy attempts made before the job gave up. |
+| `error` | Exception class and message from the last attempt. |
+
+## Example queries
+
+### Check recent runs
+
+```sql
+SELECT run_id, status, started_at, ended_at,
+       files_copied, files_skipped, files_failed,
+       round(bytes_copied / 1024 / 1024 / 1024, 2) AS gb_copied,
+       error_message
+FROM spark_catalog.iomete_system_db.lakehouse_backup_runs
+WHERE started_at > current_timestamp() - INTERVAL 2 DAYS
+ORDER BY started_at DESC;
+```
+
+A successful run has `status = 'SUCCEEDED'`, `files_failed = 0` and an
+`ended_at`. A failed run has `status = 'FAILED'` and the exception in
+`error_message`; the job also exits with a non-zero code, so the platform
+reports the failure as well.
+
+### Find runs that never finished
+
+```sql
+SELECT run_id, started_at, source_uri, target_uri
+FROM spark_catalog.iomete_system_db.lakehouse_backup_runs
+WHERE status = 'RUNNING'
+  AND started_at < current_timestamp() - INTERVAL 12 HOURS;
+```
+
+These runs lost their driver before they could record an outcome. Open the run
+in the IOMETE console to find out why.
+
+### List the files a run failed to copy
+
+```sql
+SELECT f.source_path, f.attempts_used, f.error
+FROM spark_catalog.iomete_system_db.lakehouse_backup_run_file_failures f
+WHERE f.run_id = '<run-id>'
+ORDER BY f.source_path;
+```
+
+The number of rows per run is capped by `stats.maxFailureRows`, 1000 by default.
+When the cap applies, `failures_truncated` is true on the run row and
+`files_failed` still holds the complete count.
+
+### See where a run spent its time
+
+```sql
+SELECT run_id,
+       unix_millis(ended_at) - unix_millis(started_at) AS run_wall_ms,
+       source_listing_ms, target_listing_ms, planning_ms, copy_ms, dir_create_ms,
+       (unix_millis(ended_at) - unix_millis(started_at))
+         - (source_listing_ms + target_listing_ms + planning_ms + copy_ms + dir_create_ms)
+         AS unaccounted_ms
+FROM spark_catalog.iomete_system_db.lakehouse_backup_runs
+WHERE run_id = '<run-id>';
+```
+
+A run dominated by `source_listing_ms` is limited by how long it takes to walk
+the source tree, not by how fast data moves.
+
+### Check copy throughput and cluster use
+
+```sql
+SELECT run_id,
+       round(bytes_copied / 1024 / 1024 / (copy_ms / 1000), 1) AS mb_per_sec,
+       round(copy_task_ms / copy_ms, 1)                        AS avg_concurrency,
+       task_count,
+       largest_file_bytes
+FROM spark_catalog.iomete_system_db.lakehouse_backup_runs
+WHERE run_id = '<run-id>';
+```
+
+`copy_task_ms` divided by `copy_ms` gives the average number of task slots busy
+during the copy, without needing to know how many executors the run had. Two
+causes explain a low value, and `task_count` tells them apart: a small
+`task_count` means the work was split into too few pieces, so lower
+`bytesPerTask`; a healthy `task_count` with a `largest_file_bytes` that accounts
+for most of `copy_ms` means one large file kept the run open after the rest had
+finished.
+
+### Compare runs of the same job
+
+```sql
+SELECT started_at,
+       round(bytes_copied / 1024 / 1024 / 1024, 2)             AS gb_copied,
+       round(bytes_copied / 1024 / 1024 / (copy_ms / 1000), 1) AS mb_per_sec,
+       round(copy_task_ms / copy_ms, 1)                        AS avg_concurrency,
+       source_listing_ms, copy_ms
+FROM spark_catalog.iomete_system_db.lakehouse_backup_runs
+WHERE job_id = '<job-id>' AND status = 'SUCCEEDED'
+ORDER BY started_at DESC
+LIMIT 30;
+```
+
+Because each row also stores the settings the run used, you can match a change
+in throughput against a configuration change without looking up how the job was
+defined at the time.
+
+### Compare the two sides of the copy
+
+```sql
+SELECT run_id, copy_task_ms,
+       fs_init_ms, source_read_ms, target_write_ms,
+       throttle_wait_ms, verify_ms, commit_ms, retry_sleep_ms,
+       copy_task_ms - (fs_init_ms + source_read_ms + throttle_wait_ms
+                       + target_write_ms + verify_ms + commit_ms + retry_sleep_ms)
+         AS uninstrumented_ms
+FROM spark_catalog.iomete_system_db.lakehouse_backup_runs
+WHERE run_id = '<run-id>';
+```
+
+## Troubleshooting
+
+| Signal | Likely cause | What to do |
+|---|---|---|
+| `RUNNING` long after `started_at` | The driver was killed or the run was cancelled | Check the run in the console; re-run the backup |
+| `source_listing_ms` is a large share of the run | Source enumeration dominates, and the driver does this alone | Narrow the source `prefix` if possible |
+| Low `avg_concurrency` with a small `task_count` | Work split into too few tasks | Lower `copy.bytesPerTask` |
+| Low `avg_concurrency` with `largest_file_bytes` close to `copy_ms` | One large file finished last | Expected; a single file is never split across tasks |
+| `fs_init_ms` is a large share of `copy_task_ms` | Filesystem clients rebuilt per file, common with many small files | Lower `copy.filesPerTask` so tasks are shorter |
+| `throttle_wait_ms` is large | The bandwidth limit is being reached | Expected when `copy.maxBandwidthMbPerSec` is set; raise it if there is spare capacity |
+| `source_read_ms` far above `target_write_ms` | Source storage is the bottleneck | Investigate the source system |
+| `target_write_ms` far above `source_read_ms` | Target storage is the bottleneck | Investigate the target system |
+| `verify_ms` plus `commit_ms` is large | Metadata operations dominate, common with many small files | Expected for small-file workloads |
+| `retry_sleep_ms` is large | An endpoint is returning errors rather than running slowly | Check the storage endpoint for throttling or outages |

--- a/iomete-lakehouse-backup/docs/run-stats.md
+++ b/iomete-lakehouse-backup/docs/run-stats.md
@@ -108,7 +108,7 @@ more than once. Use them to compare where time went, and use `files_copied` and
 |---|---|
 | `bytes_per_task`, `files_per_task`, `skip_identical`, `max_bandwidth_mb_per_sec` | The `copy` settings this run used. `max_bandwidth_mb_per_sec` is null when no limit was set. |
 | `task_count` | Number of Spark tasks the copy was split into. |
-| `largest_file_bytes` | Size of the largest file copied. A single file is never split across tasks, so no run finishes faster than its largest file. |
+| `largest_file_bytes` | Size of the largest file the run had to copy. A single file is never split across tasks, so no run finishes faster than its largest file. |
 
 ### Failure rows
 

--- a/iomete-lakehouse-backup/gradle.properties
+++ b/iomete-lakehouse-backup/gradle.properties
@@ -10,3 +10,5 @@ sparkVersion=3.5.7
 sparkImageRevision=v2
 # Must match the iomete/spark base image
 hadoopAwsVersion=3.4.1
+# Integration tests only: the base image provides Iceberg at runtime.
+icebergVersion=1.9.0

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/AtomicCopyIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/AtomicCopyIntegrationTest.kt
@@ -45,7 +45,11 @@ class AtomicCopyIntegrationTest {
 
         assertFailsWith<IllegalStateException> {
             IntegrationHarness.runBackup(
-                ApplicationConfig(source = IntegrationHarness.s3Config(source), target = target.config),
+                ApplicationConfig(
+                    source = IntegrationHarness.s3Config(source),
+                    target = target.config,
+                    stats = IntegrationHarness.STATS_DISABLED,
+                ),
             )
         }
 
@@ -70,7 +74,11 @@ class AtomicCopyIntegrationTest {
 
         assertFailsWith<IllegalStateException> {
             IntegrationHarness.runBackup(
-                ApplicationConfig(source = IntegrationHarness.s3Config(source), target = target.config),
+                ApplicationConfig(
+                    source = IntegrationHarness.s3Config(source),
+                    target = target.config,
+                    stats = IntegrationHarness.STATS_DISABLED,
+                ),
             )
         }
 
@@ -91,7 +99,11 @@ class AtomicCopyIntegrationTest {
         val target = scheme.target(scheme.faultOptions(afterBytes = FAIL_AT, maxFailures = 1))
 
         IntegrationHarness.runBackup(
-            ApplicationConfig(source = IntegrationHarness.s3Config(source), target = target.config),
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = target.config,
+                stats = IntegrationHarness.STATS_DISABLED,
+            ),
         )
 
         assertMatches(tree, target.read())

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
@@ -43,6 +43,7 @@ class BackupJobIntegrationTest {
             ApplicationConfig(
                 source = IntegrationHarness.s3Config(source),
                 target = target.config,
+                stats = IntegrationHarness.STATS_DISABLED,
             ),
         )
 
@@ -65,6 +66,7 @@ class BackupJobIntegrationTest {
             ApplicationConfig(
                 source = IntegrationHarness.hdfsConfig(source),
                 target = target.config,
+                stats = IntegrationHarness.STATS_DISABLED,
             ),
         )
 
@@ -87,6 +89,7 @@ class BackupJobIntegrationTest {
             ApplicationConfig(
                 source = IntegrationHarness.hdfsConfig(source),
                 target = target.config,
+                stats = IntegrationHarness.STATS_DISABLED,
             ),
         )
 
@@ -109,6 +112,7 @@ class BackupJobIntegrationTest {
             ApplicationConfig(
                 source = IntegrationHarness.hdfsConfig(source),
                 target = target.config,
+                stats = IntegrationHarness.STATS_DISABLED,
             ),
         )
 
@@ -132,6 +136,7 @@ class BackupJobIntegrationTest {
                 source = IntegrationHarness.s3Config(source),
                 target = target.config,
                 copy = CopyConfig(clockSkewToleranceMs = 0),
+                stats = IntegrationHarness.STATS_DISABLED,
             )
 
         // MinIO truncates timestamps to whole seconds, so a copy taken within the same second as its
@@ -169,6 +174,7 @@ class BackupJobIntegrationTest {
                 source = IntegrationHarness.s3Config(source),
                 target = IntegrationHarness.s3Config(IntegrationHarness.freshBucket()),
                 copy = CopyConfig(skipIdentical = false, clockSkewToleranceMs = 0),
+                stats = IntegrationHarness.STATS_DISABLED,
             )
 
         val first = IntegrationHarness.runBackup(config)
@@ -188,6 +194,7 @@ class BackupJobIntegrationTest {
             ApplicationConfig(
                 source = IntegrationHarness.s3Config(source),
                 target = IntegrationHarness.s3Config(target),
+                stats = IntegrationHarness.STATS_DISABLED,
             ),
         )
 
@@ -204,7 +211,11 @@ class BackupJobIntegrationTest {
 
         assertFailsWith<IllegalStateException> {
             IntegrationHarness.runBackup(
-                ApplicationConfig(source = IntegrationHarness.s3Config(source), target = missingTarget),
+                ApplicationConfig(
+                    source = IntegrationHarness.s3Config(source),
+                    target = missingTarget,
+                    stats = IntegrationHarness.STATS_DISABLED,
+                ),
             )
         }
     }

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BandwidthIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BandwidthIntegrationTest.kt
@@ -38,6 +38,7 @@ class BandwidthIntegrationTest {
                         source = IntegrationHarness.s3Config(source),
                         target = IntegrationHarness.s3Config(target),
                         copy = CopyConfig(maxBandwidthMbPerSec = capMbPerSec),
+                        stats = IntegrationHarness.STATS_DISABLED,
                     ),
                 )
             }
@@ -62,6 +63,7 @@ class BandwidthIntegrationTest {
             ApplicationConfig(
                 source = IntegrationHarness.s3Config(source),
                 target = IntegrationHarness.s3Config(target),
+                stats = IntegrationHarness.STATS_DISABLED,
             ),
         )
 

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/StatsIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/StatsIntegrationTest.kt
@@ -1,0 +1,187 @@
+package com.iomete.backup.integration
+
+import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.StatsConfig
+import com.iomete.backup.integration.fixtures.seedS3
+import com.iomete.backup.integration.harness.IntegrationHarness
+import com.iomete.backup.stats.FILE_FAILURES_TABLE
+import com.iomete.backup.stats.RUNS_TABLE
+import com.iomete.backup.stats.RunStatus
+import org.apache.spark.sql.Row
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class StatsIntegrationTest {
+    private val runsTable = "${IntegrationHarness.STATS_DATABASE}.$RUNS_TABLE"
+    private val failuresTable = "${IntegrationHarness.STATS_DATABASE}.$FILE_FAILURES_TABLE"
+
+    private val statsConfig = StatsConfig(database = IntegrationHarness.STATS_DATABASE)
+
+    private fun runRow(runId: String): Row {
+        val rows = IntegrationHarness.spark.sql("SELECT * FROM $runsTable WHERE run_id = '$runId'").collectAsList()
+        assertEquals(1, rows.size, "a run must end with exactly one row")
+        return rows.single()
+    }
+
+    private fun Row.long(column: String): Long = getAs<Long>(column)
+
+    @Test
+    fun `a succeeded run records its counts, bytes and phase clocks`() {
+        val source = IntegrationHarness.freshBucket()
+        val target = IntegrationHarness.freshBucket()
+        val tree =
+            mapOf(
+                "a.txt" to "alpha".toByteArray(),
+                "nested/b.txt" to "bravo".toByteArray(),
+                "nested/deeper/c.txt" to "charlie".toByteArray(),
+            )
+        seedS3(source, tree)
+        val sourceBytes = tree.values.sumOf { it.size.toLong() }
+
+        val runId = UUID.randomUUID().toString()
+        IntegrationHarness.runBackup(
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = IntegrationHarness.s3Config(target),
+                stats = statsConfig,
+            ),
+            IntegrationHarness.runSession(runId),
+        )
+
+        val row = runRow(runId)
+
+        assertEquals(RunStatus.SUCCEEDED.name, row.getAs<String>("status"))
+        assertNotNull(row.getAs<Any?>("ended_at"))
+        assertEquals(null, row.getAs<Any?>("error_message"))
+        assertEquals("s3", row.getAs<String>("source_type"))
+
+        assertEquals(tree.size.toLong(), row.long("files_listed"))
+        assertEquals(tree.size.toLong(), row.long("files_copied"))
+        assertEquals(0L, row.long("files_skipped"))
+        assertEquals(0L, row.long("files_failed"))
+        assertEquals(sourceBytes, row.long("bytes_source"))
+        assertEquals(sourceBytes, row.long("bytes_copied"))
+        assertEquals(false, row.getAs<Boolean>("failures_truncated"))
+
+        listOf("source_listing_ms", "target_listing_ms", "planning_ms", "copy_ms", "dir_create_ms")
+            .forEach { assertNotNull(row.getAs<Any?>(it), "$it must be filled on a finished run") }
+
+        assertTrue(row.long("copy_task_ms") > 0, "copy tasks must report the time they spent")
+        assertTrue(row.long("source_read_ms") > 0, "reading the source must show up")
+        assertTrue(row.long("target_write_ms") > 0, "writing the target must show up")
+        assertTrue(row.getAs<Int>("task_count") > 0)
+        assertEquals(tree.values.maxOf { it.size.toLong() }, row.long("largest_file_bytes"))
+    }
+
+    @Test
+    fun `a failed run is recorded as FAILED with a row per failed file, and still fails`() {
+        val source = IntegrationHarness.freshBucket()
+        seedS3(source, mapOf("a.txt" to "alpha".toByteArray(), "b.txt" to "bravo".toByteArray()))
+
+        val runId = UUID.randomUUID().toString()
+        assertFailsWith<IllegalStateException> {
+            IntegrationHarness.runBackup(
+                ApplicationConfig(
+                    source = IntegrationHarness.s3Config(source),
+                    // Never created, so every write fails.
+                    target = IntegrationHarness.s3Config("missing-${UUID.randomUUID()}"),
+                    stats = statsConfig,
+                ),
+                IntegrationHarness.runSession(runId),
+            )
+        }
+
+        val row = runRow(runId)
+
+        assertEquals(RunStatus.FAILED.name, row.getAs<String>("status"))
+        assertNotNull(row.getAs<String?>("error_message"))
+        assertEquals(2L, row.long("files_failed"))
+
+        val failures =
+            IntegrationHarness.spark
+                .sql("SELECT source_path, attempts_used, error FROM $failuresTable WHERE run_id = '$runId'")
+                .collectAsList()
+
+        assertEquals(2, failures.size, "each failed file is its own row")
+        assertTrue(failures.all { it.getAs<Int>("attempts_used") > 0 })
+        assertTrue(failures.all { it.getAs<String>("error").isNotBlank() })
+    }
+
+    @Test
+    fun `a failure row cap of zero records no failure rows but keeps the true count`() {
+        val source = IntegrationHarness.freshBucket()
+        seedS3(source, mapOf("a.txt" to "alpha".toByteArray(), "b.txt" to "bravo".toByteArray()))
+
+        val runId = UUID.randomUUID().toString()
+        assertFailsWith<IllegalStateException> {
+            IntegrationHarness.runBackup(
+                ApplicationConfig(
+                    source = IntegrationHarness.s3Config(source),
+                    target = IntegrationHarness.s3Config("missing-${UUID.randomUUID()}"),
+                    stats = statsConfig.copy(maxFailureRows = 0),
+                ),
+                IntegrationHarness.runSession(runId),
+            )
+        }
+
+        val row = runRow(runId)
+
+        assertEquals(2L, row.long("files_failed"))
+        assertEquals(true, row.getAs<Boolean>("failures_truncated"))
+        assertEquals(
+            0L,
+            IntegrationHarness.spark.sql("SELECT * FROM $failuresTable WHERE run_id = '$runId'").count(),
+        )
+    }
+
+    @Test
+    fun `recording disabled leaves no trace of the run`() {
+        val source = IntegrationHarness.freshBucket()
+        val target = IntegrationHarness.freshBucket()
+        seedS3(source, mapOf("a.txt" to "alpha".toByteArray()))
+
+        val runId = UUID.randomUUID().toString()
+        IntegrationHarness.runBackup(
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = IntegrationHarness.s3Config(target),
+                stats = statsConfig.copy(enabled = false),
+            ),
+            IntegrationHarness.runSession(runId),
+        )
+
+        val recorded =
+            IntegrationHarness.spark.catalog().tableExists(runsTable) &&
+                IntegrationHarness.spark.sql("SELECT * FROM $runsTable WHERE run_id = '$runId'").count() > 0
+
+        assertFalse(recorded, "a disabled recorder must not write a row")
+    }
+
+    @Test
+    fun `two runs of the same backup are two rows with different run ids`() {
+        val source = IntegrationHarness.freshBucket()
+        val target = IntegrationHarness.freshBucket()
+        seedS3(source, mapOf("a.txt" to "alpha".toByteArray()))
+
+        val config =
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = IntegrationHarness.s3Config(target),
+                stats = statsConfig,
+            )
+
+        val first = UUID.randomUUID().toString()
+        val second = UUID.randomUUID().toString()
+        IntegrationHarness.runBackup(config, IntegrationHarness.runSession(first))
+        IntegrationHarness.runBackup(config, IntegrationHarness.runSession(second))
+
+        // runRow fails on anything but exactly one row, so this also proves the merge does not duplicate.
+        assertEquals(1L, runRow(first).long("files_listed"))
+        assertEquals(1L, runRow(second).long("files_listed"))
+    }
+}

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
@@ -42,6 +42,8 @@ object IntegrationHarness {
         }
     val hdfs: MiniDFSCluster by hdfsLazy
 
+    const val STATS_DATABASE = "itcat.backup_stats"
+
     private val sparkLazy =
         lazy {
             SparkSession
@@ -50,7 +52,17 @@ object IntegrationHarness {
                 .master("local[2]")
                 .config("spark.ui.enabled", "false")
                 .config("spark.sql.shuffle.partitions", "2")
-                .orCreate
+                .config(
+                    "spark.sql.extensions",
+                    "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                ).config("spark.sql.catalog.itcat", "org.apache.iceberg.spark.SparkCatalog")
+                .config("spark.sql.catalog.itcat.type", "hadoop")
+                // Runs write from their own session; a cached table would hide their rows from the reader.
+                .config("spark.sql.catalog.itcat.cache-enabled", "false")
+                .config(
+                    "spark.sql.catalog.itcat.warehouse",
+                    File("build/test/iceberg-${UUID.randomUUID()}").absolutePath,
+                ).orCreate
         }
     val spark: SparkSession by sparkLazy
 
@@ -80,8 +92,14 @@ object IntegrationHarness {
         )
     }
 
-    fun runBackup(config: ApplicationConfig): CopyJobSummary =
-        BackupJob.run(spark, config, ConfigLoader.loadInternalConfig(config, spark.sparkContext().getConf()))
+    fun runBackup(
+        config: ApplicationConfig,
+        session: SparkSession = spark,
+    ): CopyJobSummary = BackupJob.run(session, config, ConfigLoader.loadInternalConfig(config, session.sparkContext().getConf()))
+
+    /** One platform run: same context, own `spark.app.name`, which is where the run ID comes from. */
+    fun runSession(runId: String = UUID.randomUUID().toString()): SparkSession =
+        spark.newSession().also { it.conf().set("spark.app.name", runId) }
 
     fun s3Config(
         bucket: String,

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/harness/IntegrationHarness.kt
@@ -5,6 +5,7 @@ import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.ConfigLoader
 import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
+import com.iomete.backup.config.StatsConfig
 import com.iomete.backup.copy.CopyJobSummary
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hdfs.MiniDFSCluster
@@ -43,6 +44,9 @@ object IntegrationHarness {
     val hdfs: MiniDFSCluster by hdfsLazy
 
     const val STATS_DATABASE = "itcat.backup_stats"
+
+    /** For runs that assert only on copied bytes: the default stats database has no catalog here. */
+    val STATS_DISABLED = StatsConfig(enabled = false)
 
     private val sparkLazy =
         lazy {

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
@@ -7,9 +7,13 @@ import com.iomete.backup.copy.CopyJobRunner
 import com.iomete.backup.copy.CopyJobSummary
 import com.iomete.backup.fs.useFileLister
 import com.iomete.backup.model.SourceListing
+import com.iomete.backup.stats.RunProgress
+import com.iomete.backup.stats.StatsRecorder
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
+import java.time.Instant
+import kotlin.time.measureTimedValue
 
 object BackupJob {
     private val logger = LoggerFactory.getLogger(BackupJob::class.java)
@@ -19,24 +23,57 @@ object BackupJob {
         config: ApplicationConfig,
         internalConfig: InternalConfig,
     ): CopyJobSummary {
+        val recorder = StatsRecorder(spark, config)
+        val startedAt = Instant.now()
+        val progress = RunProgress()
+
+        // Claimed before the source listing, which is the long single-threaded phase.
+        recorder.claim(startedAt)
+
+        try {
+            val summary = copy(spark, config, internalConfig, progress)
+            recorder.finalise(startedAt, progress, null)
+            return summary
+        } catch (e: Throwable) {
+            recorder.finalise(startedAt, progress, e)
+            throw e
+        }
+    }
+
+    private fun copy(
+        spark: SparkSession,
+        config: ApplicationConfig,
+        internalConfig: InternalConfig,
+        progress: RunProgress,
+    ): CopyJobSummary {
         logger.info("Enumerating source files...")
-        val (files, emptyDirs) = enumerateSource(config)
+        val (listing, listingTime) = measureTimedValue { enumerateSource(config) }
+        val (files, emptyDirs) = listing
+
+        val totalBytes = files.sumOf { it.size }
+        progress.filesListed = files.size.toLong()
+        progress.dirsListed = emptyDirs.size.toLong()
+        progress.bytesSource = totalBytes
+        progress.sourceListingMs = listingTime.inWholeMilliseconds
 
         logger.info("Found {} files to copy", files.size)
         if (emptyDirs.isNotEmpty()) {
             logger.info("Found {} empty directories to replicate", emptyDirs.size)
         }
 
-        val totalBytes = files.sumOf { it.size }
         logger.info("Total size: {} bytes ({} MB)", totalBytes, totalBytes / (1024 * 1024))
 
         if (files.isEmpty() && emptyDirs.isEmpty()) {
             logger.info("No files found in source. Nothing to copy.")
+            progress.summary = CopyJobSummary.EMPTY
             return CopyJobSummary.EMPTY
         }
 
         val copyJobResult = CopyJobRunner.run(spark, config, internalConfig, files, emptyDirs)
         val summary = copyJobResult.summary
+        progress.summary = summary
+        progress.copy = copyJobResult.stats
+        progress.failures = copyJobResult.failedResults
 
         logger.info(
             "Copy summary: {} total, {} succeeded, {} failed, {} skipped, {} bytes copied, {} bytes skipped",

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
@@ -7,6 +7,13 @@ data class ApplicationConfig(
     val source: StorageConfig,
     val target: StorageConfig,
     val copy: CopyConfig = CopyConfig(),
+    val stats: StatsConfig = StatsConfig(),
+)
+
+data class StatsConfig(
+    val enabled: Boolean = true,
+    val database: String = "spark_catalog.iomete_system_db",
+    val maxFailureRows: Int = 1000,
 )
 
 data class CopyConfig(

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
@@ -3,12 +3,15 @@ package com.iomete.backup.config.internal
 import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
+import com.iomete.backup.config.StatsConfig
 import com.iomete.backup.config.StorageConfig
 import org.apache.spark.SparkConf
 import org.slf4j.LoggerFactory
 
 object Validator {
     private val logger = LoggerFactory.getLogger(Validator::class.java)
+
+    private val DOTTED_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*")
 
     fun validate(config: ApplicationConfig): ValidationResult {
         val errors = mutableListOf<String>()
@@ -21,6 +24,8 @@ object Validator {
                 errors.add("copy: maxBandwidthMbPerSec must be a finite number greater than 0 (got $it)")
             }
         }
+
+        validateStatsConfig(config.stats, errors)
 
         return result(errors)
     }
@@ -50,6 +55,19 @@ object Validator {
             errors.forEach { logger.warn("  - {}", it) }
             ValidationResult.Invalid(errors)
         }
+
+    private fun validateStatsConfig(
+        stats: StatsConfig,
+        errors: MutableList<String>,
+    ) {
+        if (!DOTTED_IDENTIFIER.matches(stats.database)) {
+            errors.add("stats: database '${stats.database}' is not a dotted identifier (expected e.g. 'catalog.database')")
+        }
+
+        if (stats.maxFailureRows < 0) {
+            errors.add("stats: maxFailureRows cannot be negative (got ${stats.maxFailureRows})")
+        }
+    }
 
     private fun validateStorageConfig(
         storage: StorageConfig,

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
@@ -61,7 +61,7 @@ object Validator {
         errors: MutableList<String>,
     ) {
         if (!DOTTED_IDENTIFIER.matches(stats.database)) {
-            errors.add("stats: database '${stats.database}' is not a dotted identifier (expected e.g. 'catalog.database')")
+            errors.add("stats: database '${stats.database}' is not a valid identifier (expected e.g. 'catalog.database' or 'database')")
         }
 
         if (stats.maxFailureRows < 0) {

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/CopyJobRunner.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/CopyJobRunner.kt
@@ -3,6 +3,7 @@ package com.iomete.backup.copy
 import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.InternalConfig
 import com.iomete.backup.copy.internal.CopyAggregate
+import com.iomete.backup.copy.internal.CopyTimers
 import com.iomete.backup.copy.internal.FileCopier
 import com.iomete.backup.copy.internal.PathResolver
 import com.iomete.backup.copy.internal.aggregateCopyResults
@@ -17,6 +18,7 @@ import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
 import java.io.IOException
+import kotlin.time.measureTimedValue
 
 object CopyJobRunner {
     private val logger = LoggerFactory.getLogger(CopyJobRunner::class.java)
@@ -37,6 +39,7 @@ object CopyJobRunner {
         logger.info("Source root: {}", sourceRoot)
         logger.info("Target root: {}", targetRoot)
 
+        val timers = CopyTimers.register(spark.sparkContext())
         val copier =
             FileCopier(
                 sourceConfig = config.source,
@@ -44,34 +47,48 @@ object CopyJobRunner {
                 sourceRoot = sourceRoot,
                 targetRoot = targetRoot,
                 bytesPerSecPerExecutor = internalConfig.bytesPerSecPerExecutor,
+                timers = timers,
             )
 
-        val plan =
-            planCopy(
-                sourceFiles = files,
-                sourceRoot = sourceRoot,
-                targetFiles = if (config.copy.skipIdentical) listTarget(config, targetRoot) else emptyList(),
-                targetRoot = targetRoot,
-                clockSkewToleranceMs = config.copy.clockSkewToleranceMs,
-            )
+        val (targetFiles, targetListingTime) =
+            measureTimedValue {
+                if (config.copy.skipIdentical) listTarget(config, targetRoot) else emptyList()
+            }
+
+        val (planned, planningTime) =
+            measureTimedValue {
+                val plan =
+                    planCopy(
+                        sourceFiles = files,
+                        sourceRoot = sourceRoot,
+                        targetFiles = targetFiles,
+                        targetRoot = targetRoot,
+                        clockSkewToleranceMs = config.copy.clockSkewToleranceMs,
+                    )
+                plan to batchFiles(plan.toCopy, config.copy.bytesPerTask, config.copy.filesPerTask)
+            }
+        val (plan, batches) = planned
         val skippedBytes = plan.skipped.sumOf { it.size }
 
         logger.info("Skipping {} files already at the target ({} bytes)", plan.skipped.size, skippedBytes)
         plan.skipped.forEach { logger.debug("Skipped, already at target: {}", it.path) }
-
-        val batches = batchFiles(plan.toCopy, config.copy.bytesPerTask, config.copy.filesPerTask)
         logCopyPlan(plan.toCopy, batches.size, config.copy.bytesPerTask)
 
-        val fileResults =
-            if (batches.isEmpty()) {
-                CopyAggregate()
-            } else {
-                val rdd = jsc.parallelize(batches, batches.size)
-                aggregateCopyResults(
-                    rdd.flatMap { batch -> batch.asSequence().map { copier.copySingleFile(it) }.iterator() },
-                )
+        val (fileResults, copyTime) =
+            measureTimedValue {
+                if (batches.isEmpty()) {
+                    CopyAggregate(maxSampledFailures = config.stats.maxFailureRows)
+                } else {
+                    val rdd = jsc.parallelize(batches, batches.size)
+                    aggregateCopyResults(
+                        rdd.flatMap { batch -> batch.asSequence().map { copier.copySingleFile(it) }.iterator() },
+                        config.stats.maxFailureRows,
+                    )
+                }
             }
-        val directoryResults = createDirectories(config, sourceRoot, targetRoot, emptyDirectories)
+
+        val (directoryResults, dirCreateTime) =
+            measureTimedValue { createDirectories(config, sourceRoot, targetRoot, emptyDirectories) }
 
         val aggregate = directoryResults.fold(fileResults) { acc, result -> acc.add(result) }
         val summary =
@@ -96,6 +113,20 @@ object CopyJobRunner {
         return CopyJobResult(
             summary = summary,
             failedResults = aggregate.failures,
+            stats =
+                CopyStats(
+                    targetListingMs = targetListingTime.inWholeMilliseconds,
+                    planningMs = planningTime.inWholeMilliseconds,
+                    copyMs = copyTime.inWholeMilliseconds,
+                    dirCreateMs = dirCreateTime.inWholeMilliseconds,
+                    taskCount = batches.size,
+                    largestFileBytes = plan.toCopy.maxOfOrNull { it.size } ?: 0,
+                    filesCopied = fileResults.successCount.toLong(),
+                    dirsCreated = directoryResults.count { it.success }.toLong(),
+                    retriesUsed = aggregate.retriesUsed,
+                    failuresTruncated = aggregate.failuresTruncated,
+                    executor = timers.snapshot(),
+                ),
         )
     }
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/Types.kt
@@ -14,6 +14,32 @@ data class CopyResult(
 data class CopyJobResult(
     val summary: CopyJobSummary,
     val failedResults: List<CopyResult>,
+    val stats: CopyStats = CopyStats(),
+)
+
+data class CopyStats(
+    val targetListingMs: Long = 0,
+    val planningMs: Long = 0,
+    val copyMs: Long = 0,
+    val dirCreateMs: Long = 0,
+    val taskCount: Int = 0,
+    val largestFileBytes: Long = 0,
+    val filesCopied: Long = 0,
+    val dirsCreated: Long = 0,
+    val retriesUsed: Long = 0,
+    val failuresTruncated: Boolean = false,
+    val executor: ExecutorTimings = ExecutorTimings(),
+)
+
+data class ExecutorTimings(
+    val copyTaskMs: Long = 0,
+    val fsInitMs: Long = 0,
+    val sourceReadMs: Long = 0,
+    val targetWriteMs: Long = 0,
+    val throttleWaitMs: Long = 0,
+    val verifyMs: Long = 0,
+    val commitMs: Long = 0,
+    val retrySleepMs: Long = 0,
 )
 
 data class CopyJobSummary(

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/CopyAggregate.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/CopyAggregate.kt
@@ -3,40 +3,49 @@ package com.iomete.backup.copy.internal
 import com.iomete.backup.copy.CopyResult
 import org.apache.spark.api.java.JavaRDD
 
-private const val MAX_SAMPLED_FAILURES = 1000
-
 internal data class CopyAggregate(
     val successCount: Int = 0,
     val failureCount: Int = 0,
     val totalBytesCopied: Long = 0,
+    val retriesUsed: Long = 0,
     val failures: List<CopyResult> = emptyList(),
+    val maxSampledFailures: Int,
 ) : java.io.Serializable {
-    fun add(result: CopyResult): CopyAggregate =
-        if (result.success) {
-            copy(
+    val failuresTruncated: Boolean get() = failureCount > failures.size
+
+    fun add(result: CopyResult): CopyAggregate {
+        val retried = copy(retriesUsed = retriesUsed + maxOf(0, result.attemptsUsed - 1))
+
+        return if (result.success) {
+            retried.copy(
                 successCount = successCount + 1,
                 totalBytesCopied = totalBytesCopied + result.bytesCopied,
             )
         } else {
-            copy(
+            retried.copy(
                 failureCount = failureCount + 1,
-                failures = if (failures.size < MAX_SAMPLED_FAILURES) failures + result else failures,
+                failures = if (failures.size < maxSampledFailures) failures + result else failures,
             )
         }
+    }
 
     fun merge(other: CopyAggregate): CopyAggregate =
-        CopyAggregate(
+        copy(
             successCount = successCount + other.successCount,
             failureCount = failureCount + other.failureCount,
             totalBytesCopied = totalBytesCopied + other.totalBytesCopied,
-            failures = (failures + other.failures).take(MAX_SAMPLED_FAILURES),
+            retriesUsed = retriesUsed + other.retriesUsed,
+            failures = (failures + other.failures).take(maxSampledFailures),
         )
 }
 
 // Fold per-file results on the executors; only a bounded summary reaches the driver.
-internal fun aggregateCopyResults(results: JavaRDD<CopyResult>): CopyAggregate =
+internal fun aggregateCopyResults(
+    results: JavaRDD<CopyResult>,
+    maxSampledFailures: Int,
+): CopyAggregate =
     results.aggregate(
-        CopyAggregate(),
+        CopyAggregate(maxSampledFailures = maxSampledFailures),
         { acc, result -> acc.add(result) },
         { a, b -> a.merge(b) },
     )

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/CopyTimers.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/CopyTimers.kt
@@ -1,0 +1,68 @@
+package com.iomete.backup.copy.internal
+
+import com.iomete.backup.copy.ExecutorTimings
+import org.apache.spark.SparkContext
+import org.apache.spark.util.LongAccumulator
+import java.io.Serializable
+import java.util.concurrent.TimeUnit
+
+class CopyTimers(
+    val copyTask: LongAccumulator,
+    val fsInit: LongAccumulator,
+    val sourceRead: LongAccumulator,
+    val targetWrite: LongAccumulator,
+    val throttleWait: LongAccumulator,
+    val verify: LongAccumulator,
+    val commit: LongAccumulator,
+    val retrySleep: LongAccumulator,
+) : Serializable {
+    fun snapshot(): ExecutorTimings =
+        ExecutorTimings(
+            copyTaskMs = copyTask.value().toMillis(),
+            fsInitMs = fsInit.value().toMillis(),
+            sourceReadMs = sourceRead.value().toMillis(),
+            targetWriteMs = targetWrite.value().toMillis(),
+            throttleWaitMs = throttleWait.value().toMillis(),
+            verifyMs = verify.value().toMillis(),
+            commitMs = commit.value().toMillis(),
+            retrySleepMs = retrySleep.value().toMillis(),
+        )
+
+    private fun Long.toMillis(): Long = TimeUnit.NANOSECONDS.toMillis(this)
+
+    companion object {
+        fun register(sc: SparkContext): CopyTimers =
+            CopyTimers(
+                copyTask = sc.longAccumulator("copyTaskNanos"),
+                fsInit = sc.longAccumulator("fsInitNanos"),
+                sourceRead = sc.longAccumulator("sourceReadNanos"),
+                targetWrite = sc.longAccumulator("targetWriteNanos"),
+                throttleWait = sc.longAccumulator("throttleWaitNanos"),
+                verify = sc.longAccumulator("verifyNanos"),
+                commit = sc.longAccumulator("commitNanos"),
+                retrySleep = sc.longAccumulator("retrySleepNanos"),
+            )
+
+        /** Test seam only: serializing an unregistered accumulator into a task closure throws, so it cannot cross to an executor. */
+        fun unregistered(): CopyTimers =
+            CopyTimers(
+                copyTask = LongAccumulator(),
+                fsInit = LongAccumulator(),
+                sourceRead = LongAccumulator(),
+                targetWrite = LongAccumulator(),
+                throttleWait = LongAccumulator(),
+                verify = LongAccumulator(),
+                commit = LongAccumulator(),
+                retrySleep = LongAccumulator(),
+            )
+    }
+}
+
+internal inline fun <T> LongAccumulator.timeNanos(block: () -> T): T {
+    val start = System.nanoTime()
+    try {
+        return block()
+    } finally {
+        add(System.nanoTime() - start)
+    }
+}

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/FileCopier.kt
@@ -22,6 +22,7 @@ class FileCopier(
     private val bytesPerSecPerExecutor: Double? = null,
     private val maxAttempts: Int = RetryPolicy.COPY_MAX_ATTEMPTS,
     private val retryDelayMs: Long = RetryPolicy.DELAY_MS,
+    private val timers: CopyTimers = CopyTimers.unregistered(),
 ) : Serializable {
     @Transient
     private var logger = LoggerFactory.getLogger(FileCopier::class.java)
@@ -36,7 +37,9 @@ class FileCopier(
         return logger
     }
 
-    fun copySingleFile(sourceFilePath: String): CopyResult {
+    fun copySingleFile(sourceFilePath: String): CopyResult = timers.copyTask.timeNanos { copyFile(sourceFilePath) }
+
+    private fun copyFile(sourceFilePath: String): CopyResult {
         val targetFilePath =
             try {
                 PathResolver.resolveTargetPath(sourceFilePath, sourceRoot, targetRoot)
@@ -68,6 +71,7 @@ class FileCopier(
                             e.message,
                         )
                     },
+                    onRetrySleep = { timers.retrySleep.add(it) },
                 ) { attempt ->
                     attemptsUsed = attempt
                     copyOnce(sourceFilePath, targetFilePath)
@@ -107,24 +111,21 @@ class FileCopier(
         sourceFilePath: String,
         targetFilePath: String,
     ): Long {
-        val sourceConf = HadoopConfigBuilder.build(sourceConfig)
-        val targetConf = HadoopConfigBuilder.build(targetConfig)
-
         val sourcePath = Path(sourceFilePath)
         val targetPath = Path(targetFilePath)
 
-        return FileSystemFactory.create(sourceConfig, sourcePath.toUri(), sourceConf).use { sourceFs ->
-            FileSystemFactory.create(targetConfig, targetPath.toUri(), targetConf).use { targetFs ->
+        return openFileSystem(sourceConfig, sourcePath).use { sourceFs ->
+            openFileSystem(targetConfig, targetPath).use { targetFs ->
                 val tempPath = TempFiles.pathFor(targetPath)
 
-                targetPath.parent?.let { if (!targetFs.exists(it)) targetFs.mkdirs(it) }
+                timers.targetWrite.timeNanos { targetPath.parent?.let { if (!targetFs.exists(it)) targetFs.mkdirs(it) } }
 
-                val sourceLen = sourceFs.getFileStatus(sourcePath).len
+                val sourceLen = timers.sourceRead.timeNanos { sourceFs.getFileStatus(sourcePath).len }
 
                 try {
                     copyBytes(sourceFs, sourcePath, targetFs, tempPath)
 
-                    val writtenLen = targetFs.getFileStatus(tempPath).len
+                    val writtenLen = timers.verify.timeNanos { targetFs.getFileStatus(tempPath).len }
                     if (writtenLen != sourceLen) {
                         throw IOException(
                             "Length verification failed for $targetFilePath: " +
@@ -132,11 +133,13 @@ class FileCopier(
                         )
                     }
 
-                    // Overwrite deletes first (rename returns false on an existing destination), so
-                    // targetPath is briefly absent; an atomic swap needs FileContext, and HDFS only.
-                    if (targetFs.exists(targetPath)) targetFs.delete(targetPath, false)
-                    if (!targetFs.rename(tempPath, targetPath)) {
-                        throw IOException("Rename failed: $tempPath -> $targetFilePath")
+                    timers.commit.timeNanos {
+                        // Overwrite deletes first (rename returns false on an existing destination), so
+                        // targetPath is briefly absent; an atomic swap needs FileContext, and HDFS only.
+                        if (targetFs.exists(targetPath)) targetFs.delete(targetPath, false)
+                        if (!targetFs.rename(tempPath, targetPath)) {
+                            throw IOException("Rename failed: $tempPath -> $targetFilePath")
+                        }
                     }
                     sourceLen
                 } catch (e: Exception) {
@@ -147,6 +150,14 @@ class FileCopier(
         }
     }
 
+    private fun openFileSystem(
+        config: StorageConfig,
+        path: Path,
+    ): FileSystem =
+        timers.fsInit.timeNanos {
+            FileSystemFactory.create(config, path.toUri(), HadoopConfigBuilder.build(config))
+        }
+
     private fun copyBytes(
         sourceFs: FileSystem,
         sourcePath: Path,
@@ -155,15 +166,33 @@ class FileCopier(
     ) {
         val limiter = bytesPerSecPerExecutor?.let { RateLimiter.shared(it) }
         val buffer = ByteArray(BUFFER_SIZE)
+        var readNanos = 0L
+        var throttleNanos = 0L
 
-        sourceFs.open(sourcePath, BUFFER_SIZE).use { input ->
-            targetFs.create(tempPath, true, BUFFER_SIZE).use { output ->
-                while (true) {
-                    val read = input.read(buffer)
-                    if (read < 0) break
-                    limiter?.acquire(read.toLong())
-                    output.write(buffer, 0, read)
+        timers.sourceRead.timeNanos { sourceFs.open(sourcePath, BUFFER_SIZE) }.use { input ->
+            val startNanos = System.nanoTime()
+            try {
+                targetFs.create(tempPath, true, BUFFER_SIZE).use { output ->
+                    while (true) {
+                        val readStartNanos = System.nanoTime()
+                        val read = input.read(buffer)
+                        readNanos += System.nanoTime() - readStartNanos
+                        if (read < 0) break
+
+                        val throttleStartNanos = System.nanoTime()
+                        limiter?.acquire(read.toLong())
+                        throttleNanos += System.nanoTime() - throttleStartNanos
+
+                        output.write(buffer, 0, read)
+                    }
                 }
+            } finally {
+                // On S3A the upload happens in close(), which .use owns, so target time is the
+                // window around the write side minus the read and throttle nested inside it.
+                val windowNanos = System.nanoTime() - startNanos
+                timers.sourceRead.add(readNanos)
+                timers.throttleWait.add(throttleNanos)
+                timers.targetWrite.add(windowNanos - readNanos - throttleNanos)
             }
         }
     }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/RateLimiter.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/RateLimiter.kt
@@ -2,7 +2,7 @@ package com.iomete.backup.copy.internal
 
 import java.util.concurrent.TimeUnit
 
-private const val NANOS_PER_SECOND = 1000L * 1000 * 1000
+private val NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1)
 
 internal class RateLimiter(
     val bytesPerSec: Double,

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/RetryPolicy.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/copy/internal/RetryPolicy.kt
@@ -19,6 +19,7 @@ internal fun <T> withRetries(
     maxAttempts: Int,
     retryDelayMs: Long,
     onFailedAttempt: (attempt: Int, e: Exception) -> Unit = { _, _ -> },
+    onRetrySleep: (elapsedNanos: Long) -> Unit = { },
     block: (attempt: Int) -> T,
 ): T {
     for (attempt in 1..maxAttempts) {
@@ -29,8 +30,10 @@ internal fun <T> withRetries(
 
             if (isTerminal(e) || attempt == maxAttempts) throw e
 
+            val sleepStartNanos = System.nanoTime()
             try {
                 Thread.sleep(fullJitterDelayMs(attempt, retryDelayMs))
+                onRetrySleep(System.nanoTime() - sleepStartNanos)
             } catch (interrupted: InterruptedException) {
                 Thread.currentThread().interrupt()
                 interrupted.addSuppressed(e)

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/RunStats.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/RunStats.kt
@@ -1,0 +1,226 @@
+package com.iomete.backup.stats
+
+import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.HdfsConfig
+import com.iomete.backup.config.S3Config
+import com.iomete.backup.config.StorageConfig
+import com.iomete.backup.copy.CopyJobSummary
+import com.iomete.backup.copy.CopyResult
+import com.iomete.backup.copy.CopyStats
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.Metadata
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
+import java.sql.Timestamp
+import java.time.Instant
+
+const val RUNS_TABLE = "lakehouse_backup_runs"
+const val FILE_FAILURES_TABLE = "lakehouse_backup_run_file_failures"
+
+enum class RunStatus { RUNNING, SUCCEEDED, FAILED }
+
+private fun field(
+    name: String,
+    type: DataType,
+    comment: String,
+    nullable: Boolean = true,
+) = StructField(name, type, nullable, Metadata.empty()).withComment(comment)
+
+private val STRING = DataTypes.StringType
+private val LONG = DataTypes.LongType
+private val INT = DataTypes.IntegerType
+private val DOUBLE = DataTypes.DoubleType
+private val BOOLEAN = DataTypes.BooleanType
+private val TIMESTAMP = DataTypes.TimestampType
+
+val RUNS_SCHEMA: StructType =
+    StructType(
+        arrayOf(
+            field("run_id", STRING, "the run ID shown in the console", nullable = false),
+            field("job_id", STRING, "groups every run of one job"),
+            field("started_by", STRING, "null means a scheduled run"),
+            field("source_type", STRING, "s3 or hdfs", nullable = false),
+            field("source_uri", STRING, "root URI the run reads from", nullable = false),
+            field("target_type", STRING, "s3 or hdfs", nullable = false),
+            field("target_uri", STRING, "root URI the run writes to", nullable = false),
+            field(
+                "status",
+                STRING,
+                "RUNNING, SUCCEEDED or FAILED; RUNNING after the run means the driver died",
+                nullable = false,
+            ),
+            field("error_message", STRING, "null unless FAILED"),
+            field(
+                "started_at",
+                TIMESTAMP,
+                "when the run claimed this row, before source enumeration",
+                nullable = false,
+            ),
+            field("ended_at", TIMESTAMP, "null while RUNNING"),
+            field("files_listed", LONG, "files found by source enumeration"),
+            field("dirs_listed", LONG, "empty directories found; HDFS source only"),
+            field("files_copied", LONG, "files written to the target"),
+            field("files_skipped", LONG, "files already identical at the target"),
+            field("files_failed", LONG, "true failure count, not the capped row count in the failures table"),
+            field("dirs_created", LONG, "empty directories replicated at the target"),
+            field("retries_used", LONG, "sum of attempts beyond the first across every entry"),
+            field(
+                "failures_truncated",
+                BOOLEAN,
+                "failure rows hit stats.maxFailureRows, so the failures table is a sample",
+            ),
+            field("bytes_source", LONG, "bytes across everything enumerated at the source"),
+            field("bytes_copied", LONG, "bytes written to the target"),
+            field("bytes_skipped", LONG, "bytes in files already identical at the target"),
+            field("source_listing_ms", LONG, "driver phase: enumerating the source tree"),
+            field(
+                "target_listing_ms",
+                LONG,
+                "driver phase: enumerating the target tree; 0 when skipIdentical is false",
+            ),
+            field("planning_ms", LONG, "driver phase: deciding what to copy and skip"),
+            field("copy_ms", LONG, "driver phase: wall clock of the distributed copy"),
+            field("dir_create_ms", LONG, "driver phase: replicating empty directories"),
+            field(
+                "copy_task_ms",
+                LONG,
+                "per-file wall time summed across tasks; divided by copy_ms gives average concurrency",
+            ),
+            field("fs_init_ms", LONG, "executor time building a FileSystem per file"),
+            field("source_read_ms", LONG, "executor time reading from the source"),
+            field("target_write_ms", LONG, "executor time writing to the target, including the closing upload"),
+            field("throttle_wait_ms", LONG, "executor time blocked by the bandwidth cap"),
+            field("verify_ms", LONG, "executor time on the post-write length check"),
+            field("commit_ms", LONG, "executor time on the delete and rename that publish a file"),
+            field("retry_sleep_ms", LONG, "executor time sleeping between copy attempts"),
+            field("bytes_per_task", LONG, "copy.bytesPerTask for this run", nullable = false),
+            field("files_per_task", INT, "copy.filesPerTask for this run", nullable = false),
+            field("skip_identical", BOOLEAN, "copy.skipIdentical for this run", nullable = false),
+            field("max_bandwidth_mb_per_sec", DOUBLE, "copy.maxBandwidthMbPerSec for this run; null means uncapped"),
+            field("task_count", INT, "Spark tasks the copy was split into"),
+            field("largest_file_bytes", LONG, "biggest single file copied; a run cannot finish faster than this file"),
+        ),
+    )
+
+val FILE_FAILURES_SCHEMA: StructType =
+    StructType(
+        arrayOf(
+            field("run_id", STRING, "joins to lakehouse_backup_runs.run_id", nullable = false),
+            field(
+                "started_at",
+                TIMESTAMP,
+                "copied from the run row so both tables share a partition key",
+                nullable = false,
+            ),
+            field("source_path", STRING, "entry that failed to copy", nullable = false),
+            field("target_path", STRING, "where it would have gone", nullable = false),
+            field("attempts_used", INT, "copy attempts before giving up", nullable = false),
+            field("error", STRING, "exception class and message from the last attempt", nullable = false),
+        ),
+    )
+
+data class RunIdentity(
+    val runId: String,
+    val jobId: String?,
+    val startedBy: String?,
+) {
+    companion object {
+        fun current(spark: SparkSession): RunIdentity =
+            RunIdentity(
+                runId = spark.conf().get("spark.app.name"),
+                jobId = env("IOMETE_EXTERNAL_JOB_ID"),
+                startedBy = env("IOMETE_JOB_STARTED_BY"),
+            )
+
+        private fun env(name: String): String? = System.getenv(name)?.takeIf { it.isNotBlank() }
+    }
+}
+
+class RunProgress {
+    var filesListed: Long? = null
+    var dirsListed: Long? = null
+    var bytesSource: Long? = null
+    var sourceListingMs: Long? = null
+    var summary: CopyJobSummary? = null
+    var copy: CopyStats? = null
+    var failures: List<CopyResult> = emptyList()
+}
+
+fun runRow(
+    identity: RunIdentity,
+    config: ApplicationConfig,
+    startedAt: Instant,
+    endedAt: Instant?,
+    status: RunStatus,
+    errorMessage: String?,
+    progress: RunProgress,
+): Map<String, Any?> {
+    val summary = progress.summary
+    val copy = progress.copy
+
+    return mapOf(
+        "run_id" to identity.runId,
+        "job_id" to identity.jobId,
+        "started_by" to identity.startedBy,
+        "source_type" to storageType(config.source),
+        "source_uri" to config.source.rootUri,
+        "target_type" to storageType(config.target),
+        "target_uri" to config.target.rootUri,
+        "status" to status.name,
+        "error_message" to errorMessage,
+        "started_at" to Timestamp.from(startedAt),
+        "ended_at" to endedAt?.let { Timestamp.from(it) },
+        "files_listed" to progress.filesListed,
+        "dirs_listed" to progress.dirsListed,
+        "files_copied" to copy?.filesCopied,
+        "files_skipped" to summary?.skippedCount?.toLong(),
+        "files_failed" to summary?.failureCount?.toLong(),
+        "dirs_created" to copy?.dirsCreated,
+        "retries_used" to copy?.retriesUsed,
+        "failures_truncated" to copy?.failuresTruncated,
+        "bytes_source" to progress.bytesSource,
+        "bytes_copied" to summary?.totalBytesCopied,
+        "bytes_skipped" to summary?.skippedBytes,
+        "source_listing_ms" to progress.sourceListingMs,
+        "target_listing_ms" to copy?.targetListingMs,
+        "planning_ms" to copy?.planningMs,
+        "copy_ms" to copy?.copyMs,
+        "dir_create_ms" to copy?.dirCreateMs,
+        "copy_task_ms" to copy?.executor?.copyTaskMs,
+        "fs_init_ms" to copy?.executor?.fsInitMs,
+        "source_read_ms" to copy?.executor?.sourceReadMs,
+        "target_write_ms" to copy?.executor?.targetWriteMs,
+        "throttle_wait_ms" to copy?.executor?.throttleWaitMs,
+        "verify_ms" to copy?.executor?.verifyMs,
+        "commit_ms" to copy?.executor?.commitMs,
+        "retry_sleep_ms" to copy?.executor?.retrySleepMs,
+        "bytes_per_task" to config.copy.bytesPerTask,
+        "files_per_task" to config.copy.filesPerTask,
+        "skip_identical" to config.copy.skipIdentical,
+        "max_bandwidth_mb_per_sec" to config.copy.maxBandwidthMbPerSec,
+        "task_count" to copy?.taskCount,
+        "largest_file_bytes" to copy?.largestFileBytes,
+    )
+}
+
+fun fileFailureRow(
+    identity: RunIdentity,
+    startedAt: Instant,
+    result: CopyResult,
+): Map<String, Any?> =
+    mapOf(
+        "run_id" to identity.runId,
+        "started_at" to Timestamp.from(startedAt),
+        "source_path" to result.sourcePath,
+        "target_path" to result.targetPath,
+        "attempts_used" to result.attemptsUsed,
+        "error" to (result.error ?: "unknown"),
+    )
+
+private fun storageType(config: StorageConfig): String =
+    when (config) {
+        is S3Config -> "s3"
+        is HdfsConfig -> "hdfs"
+    }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/RunStats.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/RunStats.kt
@@ -100,7 +100,7 @@ val RUNS_SCHEMA: StructType =
             field("skip_identical", BOOLEAN, "copy.skipIdentical for this run", nullable = false),
             field("max_bandwidth_mb_per_sec", DOUBLE, "copy.maxBandwidthMbPerSec for this run; null means uncapped"),
             field("task_count", INT, "Spark tasks the copy was split into"),
-            field("largest_file_bytes", LONG, "biggest single file copied; a run cannot finish faster than this file"),
+            field("largest_file_bytes", LONG, "biggest single file the run had to copy"),
         ),
     )
 

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/StatsRecorder.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/StatsRecorder.kt
@@ -1,0 +1,138 @@
+package com.iomete.backup.stats
+
+import com.iomete.backup.config.ApplicationConfig
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.RowFactory
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.StructType
+import org.slf4j.LoggerFactory
+import java.sql.Timestamp
+import java.time.Instant
+
+private const val FINAL_ROW_VIEW = "lakehouse_backup_run_final"
+
+/**
+ * A row still RUNNING after the run is a run whose driver never came back to finalise it.
+ *
+ * Every write is best effort: a catalog that is down must not fail a backup that copied correctly.
+ */
+class StatsRecorder(
+    private val spark: SparkSession,
+    private val config: ApplicationConfig,
+) {
+    private val logger = LoggerFactory.getLogger(StatsRecorder::class.java)
+
+    private val runsTable = "${config.stats.database}.$RUNS_TABLE"
+    private val failuresTable = "${config.stats.database}.$FILE_FAILURES_TABLE"
+
+    // Resolved inside the guarded path so a session without spark.app.name cannot fail the backup.
+    private val identity: RunIdentity by lazy { RunIdentity.current(spark) }
+
+    fun claim(startedAt: Instant) =
+        record("claim") {
+            ensureTables()
+
+            val row = runRow(identity, config, startedAt, null, RunStatus.RUNNING, null, RunProgress())
+            dataFrame(RUNS_SCHEMA, listOf(row)).writeTo(runsTable).append()
+
+            logger.info("Recording run {} in {}", identity.runId, runsTable)
+        }
+
+    fun finalise(
+        startedAt: Instant,
+        progress: RunProgress,
+        error: Throwable?,
+    ) = record("finalise") {
+        // Repeated so a run whose claim failed is still recorded by the INSERT branch of the merge.
+        ensureTables()
+
+        val status = if (error == null) RunStatus.SUCCEEDED else RunStatus.FAILED
+        val message = error?.let { "${it.javaClass.simpleName}: ${it.message}" }
+        val row = runRow(identity, config, startedAt, Instant.now(), status, message, progress)
+
+        dataFrame(RUNS_SCHEMA, listOf(row)).createOrReplaceTempView(FINAL_ROW_VIEW)
+        // started_at is in the join so the merge prunes to one partition; the claim wrote the same value.
+        spark.sql(
+            """
+            MERGE INTO $runsTable t USING $FINAL_ROW_VIEW s
+              ON t.run_id = s.run_id AND t.started_at = s.started_at
+            WHEN MATCHED THEN UPDATE SET *
+            WHEN NOT MATCHED THEN INSERT *
+            """.trimIndent(),
+        )
+
+        val failures = progress.failures.map { fileFailureRow(identity, startedAt, it) }
+        if (failures.isNotEmpty()) {
+            dataFrame(FILE_FAILURES_SCHEMA, failures).writeTo(failuresTable).append()
+        }
+    }
+
+    private fun ensureTables() {
+        spark.sql("CREATE DATABASE IF NOT EXISTS ${config.stats.database}")
+        spark.sql(createTableSql(runsTable, RUNS_SCHEMA))
+        spark.sql(createTableSql(failuresTable, FILE_FAILURES_SCHEMA))
+    }
+
+    private fun dataFrame(
+        schema: StructType,
+        rows: List<Map<String, Any?>>,
+    ) = spark.createDataFrame(rows.map { rowOf(schema, it) }, schema)
+
+    private inline fun record(
+        phase: String,
+        block: () -> Unit,
+    ) {
+        if (!config.stats.enabled) return
+
+        try {
+            block()
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        } catch (e: Throwable) {
+            // Throwable, not Exception: a missing Iceberg runtime arrives as an Error, and a backup
+            // that copied every byte is still a success.
+            logger.warn("Run stats {} failed; the backup is unaffected: {}", phase, e.toString(), e)
+        }
+    }
+}
+
+internal fun createTableSql(
+    table: String,
+    schema: StructType,
+): String =
+    """
+    CREATE TABLE IF NOT EXISTS $table (${schema.toDDL()})
+    USING iceberg
+    PARTITIONED BY (days(started_at))
+    """.trimIndent()
+
+// Spark only rejects a mistyped value once the write reaches the executors, far from the mapping.
+private val EXTERNAL_TYPES: Map<DataType, Class<*>> =
+    mapOf(
+        DataTypes.StringType to String::class.java,
+        DataTypes.LongType to Long::class.javaObjectType,
+        DataTypes.IntegerType to Int::class.javaObjectType,
+        DataTypes.DoubleType to Double::class.javaObjectType,
+        DataTypes.BooleanType to Boolean::class.javaObjectType,
+        DataTypes.TimestampType to Timestamp::class.java,
+    )
+
+internal fun rowOf(
+    schema: StructType,
+    values: Map<String, Any?>,
+): Row {
+    val names = schema.fieldNames().toSet()
+    require(values.keys == names) {
+        "row keys do not match the schema: missing ${names - values.keys}, unknown ${values.keys - names}"
+    }
+    schema.fields().forEach { field ->
+        val value = values[field.name()] ?: return@forEach
+        val expected = EXTERNAL_TYPES.getValue(field.dataType())
+        require(expected.isInstance(value)) {
+            "${field.name()} is ${field.dataType().simpleString()} but got a ${value.javaClass.simpleName}"
+        }
+    }
+    return RowFactory.create(*schema.fieldNames().map { values[it] }.toTypedArray())
+}

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/StatsRecorder.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/StatsRecorder.kt
@@ -53,11 +53,11 @@ class StatsRecorder(
         val row = runRow(identity, config, startedAt, Instant.now(), status, message, progress)
 
         dataFrame(RUNS_SCHEMA, listOf(row)).createOrReplaceTempView(FINAL_ROW_VIEW)
-        // started_at is in the join so the merge prunes to one partition; the claim wrote the same value.
+
         spark.sql(
             """
             MERGE INTO $runsTable t USING $FINAL_ROW_VIEW s
-              ON t.run_id = s.run_id AND t.started_at = s.started_at
+              ON t.run_id = s.run_id
             WHEN MATCHED THEN UPDATE SET *
             WHEN NOT MATCHED THEN INSERT *
             """.trimIndent(),

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/StatsRecorder.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/StatsRecorder.kt
@@ -1,15 +1,20 @@
 package com.iomete.backup.stats
 
 import com.iomete.backup.config.ApplicationConfig
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.RowFactory
+import com.iomete.backup.stats.internal.FILE_FAILURES_SCHEMA
+import com.iomete.backup.stats.internal.RUNS_SCHEMA
+import com.iomete.backup.stats.internal.RunIdentity
+import com.iomete.backup.stats.internal.createTableSql
+import com.iomete.backup.stats.internal.fileFailureRow
+import com.iomete.backup.stats.internal.rowOf
+import com.iomete.backup.stats.internal.runRow
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
-import java.sql.Timestamp
 import java.time.Instant
+
+const val RUNS_TABLE = "lakehouse_backup_runs"
+const val FILE_FAILURES_TABLE = "lakehouse_backup_run_file_failures"
 
 private const val FINAL_ROW_VIEW = "lakehouse_backup_run_final"
 
@@ -96,43 +101,4 @@ class StatsRecorder(
             logger.warn("Run stats {} failed; the backup is unaffected: {}", phase, e.toString(), e)
         }
     }
-}
-
-internal fun createTableSql(
-    table: String,
-    schema: StructType,
-): String =
-    """
-    CREATE TABLE IF NOT EXISTS $table (${schema.toDDL()})
-    USING iceberg
-    PARTITIONED BY (days(started_at))
-    """.trimIndent()
-
-// Spark only rejects a mistyped value once the write reaches the executors, far from the mapping.
-private val EXTERNAL_TYPES: Map<DataType, Class<*>> =
-    mapOf(
-        DataTypes.StringType to String::class.java,
-        DataTypes.LongType to Long::class.javaObjectType,
-        DataTypes.IntegerType to Int::class.javaObjectType,
-        DataTypes.DoubleType to Double::class.javaObjectType,
-        DataTypes.BooleanType to Boolean::class.javaObjectType,
-        DataTypes.TimestampType to Timestamp::class.java,
-    )
-
-internal fun rowOf(
-    schema: StructType,
-    values: Map<String, Any?>,
-): Row {
-    val names = schema.fieldNames().toSet()
-    require(values.keys == names) {
-        "row keys do not match the schema: missing ${names - values.keys}, unknown ${values.keys - names}"
-    }
-    schema.fields().forEach { field ->
-        val value = values[field.name()] ?: return@forEach
-        val expected = EXTERNAL_TYPES.getValue(field.dataType())
-        require(expected.isInstance(value)) {
-            "${field.name()} is ${field.dataType().simpleString()} but got a ${value.javaClass.simpleName}"
-        }
-    }
-    return RowFactory.create(*schema.fieldNames().map { values[it] }.toTypedArray())
 }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/Types.kt
@@ -1,0 +1,18 @@
+package com.iomete.backup.stats
+
+import com.iomete.backup.copy.CopyJobSummary
+import com.iomete.backup.copy.CopyResult
+import com.iomete.backup.copy.CopyStats
+
+enum class RunStatus { RUNNING, SUCCEEDED, FAILED }
+
+/** Filled in as the run proceeds so a run that throws still reports how far it got. */
+class RunProgress {
+    var filesListed: Long? = null
+    var dirsListed: Long? = null
+    var bytesSource: Long? = null
+    var sourceListingMs: Long? = null
+    var summary: CopyJobSummary? = null
+    var copy: CopyStats? = null
+    var failures: List<CopyResult> = emptyList()
+}

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/internal/RowMapping.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/internal/RowMapping.kt
@@ -1,0 +1,140 @@
+package com.iomete.backup.stats.internal
+
+import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.HdfsConfig
+import com.iomete.backup.config.S3Config
+import com.iomete.backup.config.StorageConfig
+import com.iomete.backup.copy.CopyResult
+import com.iomete.backup.stats.RunProgress
+import com.iomete.backup.stats.RunStatus
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.RowFactory
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.StructType
+import java.sql.Timestamp
+import java.time.Instant
+
+internal data class RunIdentity(
+    val runId: String,
+    val jobId: String?,
+    val startedBy: String?,
+) {
+    companion object {
+        fun current(spark: SparkSession): RunIdentity =
+            RunIdentity(
+                runId = spark.conf().get("spark.app.name"),
+                jobId = env("IOMETE_EXTERNAL_JOB_ID"),
+                startedBy = env("IOMETE_JOB_STARTED_BY"),
+            )
+
+        private fun env(name: String): String? = System.getenv(name)?.takeIf { it.isNotBlank() }
+    }
+}
+
+internal fun runRow(
+    identity: RunIdentity,
+    config: ApplicationConfig,
+    startedAt: Instant,
+    endedAt: Instant?,
+    status: RunStatus,
+    errorMessage: String?,
+    progress: RunProgress,
+): Map<String, Any?> {
+    val summary = progress.summary
+    val copy = progress.copy
+
+    return mapOf(
+        "run_id" to identity.runId,
+        "job_id" to identity.jobId,
+        "started_by" to identity.startedBy,
+        "source_type" to storageType(config.source),
+        "source_uri" to config.source.rootUri,
+        "target_type" to storageType(config.target),
+        "target_uri" to config.target.rootUri,
+        "status" to status.name,
+        "error_message" to errorMessage,
+        "started_at" to Timestamp.from(startedAt),
+        "ended_at" to endedAt?.let { Timestamp.from(it) },
+        "files_listed" to progress.filesListed,
+        "dirs_listed" to progress.dirsListed,
+        "files_copied" to copy?.filesCopied,
+        "files_skipped" to summary?.skippedCount?.toLong(),
+        "files_failed" to summary?.failureCount?.toLong(),
+        "dirs_created" to copy?.dirsCreated,
+        "retries_used" to copy?.retriesUsed,
+        "failures_truncated" to copy?.failuresTruncated,
+        "bytes_source" to progress.bytesSource,
+        "bytes_copied" to summary?.totalBytesCopied,
+        "bytes_skipped" to summary?.skippedBytes,
+        "source_listing_ms" to progress.sourceListingMs,
+        "target_listing_ms" to copy?.targetListingMs,
+        "planning_ms" to copy?.planningMs,
+        "copy_ms" to copy?.copyMs,
+        "dir_create_ms" to copy?.dirCreateMs,
+        "copy_task_ms" to copy?.executor?.copyTaskMs,
+        "fs_init_ms" to copy?.executor?.fsInitMs,
+        "source_read_ms" to copy?.executor?.sourceReadMs,
+        "target_write_ms" to copy?.executor?.targetWriteMs,
+        "throttle_wait_ms" to copy?.executor?.throttleWaitMs,
+        "verify_ms" to copy?.executor?.verifyMs,
+        "commit_ms" to copy?.executor?.commitMs,
+        "retry_sleep_ms" to copy?.executor?.retrySleepMs,
+        "bytes_per_task" to config.copy.bytesPerTask,
+        "files_per_task" to config.copy.filesPerTask,
+        "skip_identical" to config.copy.skipIdentical,
+        "max_bandwidth_mb_per_sec" to config.copy.maxBandwidthMbPerSec,
+        "task_count" to copy?.taskCount,
+        "largest_file_bytes" to copy?.largestFileBytes,
+    )
+}
+
+internal fun fileFailureRow(
+    identity: RunIdentity,
+    startedAt: Instant,
+    result: CopyResult,
+): Map<String, Any?> =
+    mapOf(
+        "run_id" to identity.runId,
+        "started_at" to Timestamp.from(startedAt),
+        "source_path" to result.sourcePath,
+        "target_path" to result.targetPath,
+        "attempts_used" to result.attemptsUsed,
+        "error" to (result.error ?: "unknown"),
+    )
+
+private fun storageType(config: StorageConfig): String =
+    when (config) {
+        is S3Config -> "s3"
+        is HdfsConfig -> "hdfs"
+    }
+
+// Spark only rejects a mistyped value once the write reaches the executors, far from the mapping.
+private val EXTERNAL_TYPES: Map<DataType, Class<*>> =
+    mapOf(
+        DataTypes.StringType to String::class.java,
+        DataTypes.LongType to Long::class.javaObjectType,
+        DataTypes.IntegerType to Int::class.javaObjectType,
+        DataTypes.DoubleType to Double::class.javaObjectType,
+        DataTypes.BooleanType to Boolean::class.javaObjectType,
+        DataTypes.TimestampType to Timestamp::class.java,
+    )
+
+internal fun rowOf(
+    schema: StructType,
+    values: Map<String, Any?>,
+): Row {
+    val names = schema.fieldNames().toSet()
+    require(values.keys == names) {
+        "row keys do not match the schema: missing ${names - values.keys}, unknown ${values.keys - names}"
+    }
+    schema.fields().forEach { field ->
+        val value = values[field.name()] ?: return@forEach
+        val expected = EXTERNAL_TYPES.getValue(field.dataType())
+        require(expected.isInstance(value)) {
+            "${field.name()} is ${field.dataType().simpleString()} but got a ${value.javaClass.simpleName}"
+        }
+    }
+    return RowFactory.create(*schema.fieldNames().map { values[it] }.toTypedArray())
+}

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/internal/Schema.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/stats/internal/Schema.kt
@@ -1,25 +1,10 @@
-package com.iomete.backup.stats
+package com.iomete.backup.stats.internal
 
-import com.iomete.backup.config.ApplicationConfig
-import com.iomete.backup.config.HdfsConfig
-import com.iomete.backup.config.S3Config
-import com.iomete.backup.config.StorageConfig
-import com.iomete.backup.copy.CopyJobSummary
-import com.iomete.backup.copy.CopyResult
-import com.iomete.backup.copy.CopyStats
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.Metadata
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
-import java.sql.Timestamp
-import java.time.Instant
-
-const val RUNS_TABLE = "lakehouse_backup_runs"
-const val FILE_FAILURES_TABLE = "lakehouse_backup_run_file_failures"
-
-enum class RunStatus { RUNNING, SUCCEEDED, FAILED }
 
 private fun field(
     name: String,
@@ -35,7 +20,7 @@ private val DOUBLE = DataTypes.DoubleType
 private val BOOLEAN = DataTypes.BooleanType
 private val TIMESTAMP = DataTypes.TimestampType
 
-val RUNS_SCHEMA: StructType =
+internal val RUNS_SCHEMA: StructType =
     StructType(
         arrayOf(
             field("run_id", STRING, "the run ID shown in the console", nullable = false),
@@ -104,7 +89,7 @@ val RUNS_SCHEMA: StructType =
         ),
     )
 
-val FILE_FAILURES_SCHEMA: StructType =
+internal val FILE_FAILURES_SCHEMA: StructType =
     StructType(
         arrayOf(
             field("run_id", STRING, "joins to lakehouse_backup_runs.run_id", nullable = false),
@@ -121,106 +106,12 @@ val FILE_FAILURES_SCHEMA: StructType =
         ),
     )
 
-data class RunIdentity(
-    val runId: String,
-    val jobId: String?,
-    val startedBy: String?,
-) {
-    companion object {
-        fun current(spark: SparkSession): RunIdentity =
-            RunIdentity(
-                runId = spark.conf().get("spark.app.name"),
-                jobId = env("IOMETE_EXTERNAL_JOB_ID"),
-                startedBy = env("IOMETE_JOB_STARTED_BY"),
-            )
-
-        private fun env(name: String): String? = System.getenv(name)?.takeIf { it.isNotBlank() }
-    }
-}
-
-class RunProgress {
-    var filesListed: Long? = null
-    var dirsListed: Long? = null
-    var bytesSource: Long? = null
-    var sourceListingMs: Long? = null
-    var summary: CopyJobSummary? = null
-    var copy: CopyStats? = null
-    var failures: List<CopyResult> = emptyList()
-}
-
-fun runRow(
-    identity: RunIdentity,
-    config: ApplicationConfig,
-    startedAt: Instant,
-    endedAt: Instant?,
-    status: RunStatus,
-    errorMessage: String?,
-    progress: RunProgress,
-): Map<String, Any?> {
-    val summary = progress.summary
-    val copy = progress.copy
-
-    return mapOf(
-        "run_id" to identity.runId,
-        "job_id" to identity.jobId,
-        "started_by" to identity.startedBy,
-        "source_type" to storageType(config.source),
-        "source_uri" to config.source.rootUri,
-        "target_type" to storageType(config.target),
-        "target_uri" to config.target.rootUri,
-        "status" to status.name,
-        "error_message" to errorMessage,
-        "started_at" to Timestamp.from(startedAt),
-        "ended_at" to endedAt?.let { Timestamp.from(it) },
-        "files_listed" to progress.filesListed,
-        "dirs_listed" to progress.dirsListed,
-        "files_copied" to copy?.filesCopied,
-        "files_skipped" to summary?.skippedCount?.toLong(),
-        "files_failed" to summary?.failureCount?.toLong(),
-        "dirs_created" to copy?.dirsCreated,
-        "retries_used" to copy?.retriesUsed,
-        "failures_truncated" to copy?.failuresTruncated,
-        "bytes_source" to progress.bytesSource,
-        "bytes_copied" to summary?.totalBytesCopied,
-        "bytes_skipped" to summary?.skippedBytes,
-        "source_listing_ms" to progress.sourceListingMs,
-        "target_listing_ms" to copy?.targetListingMs,
-        "planning_ms" to copy?.planningMs,
-        "copy_ms" to copy?.copyMs,
-        "dir_create_ms" to copy?.dirCreateMs,
-        "copy_task_ms" to copy?.executor?.copyTaskMs,
-        "fs_init_ms" to copy?.executor?.fsInitMs,
-        "source_read_ms" to copy?.executor?.sourceReadMs,
-        "target_write_ms" to copy?.executor?.targetWriteMs,
-        "throttle_wait_ms" to copy?.executor?.throttleWaitMs,
-        "verify_ms" to copy?.executor?.verifyMs,
-        "commit_ms" to copy?.executor?.commitMs,
-        "retry_sleep_ms" to copy?.executor?.retrySleepMs,
-        "bytes_per_task" to config.copy.bytesPerTask,
-        "files_per_task" to config.copy.filesPerTask,
-        "skip_identical" to config.copy.skipIdentical,
-        "max_bandwidth_mb_per_sec" to config.copy.maxBandwidthMbPerSec,
-        "task_count" to copy?.taskCount,
-        "largest_file_bytes" to copy?.largestFileBytes,
-    )
-}
-
-fun fileFailureRow(
-    identity: RunIdentity,
-    startedAt: Instant,
-    result: CopyResult,
-): Map<String, Any?> =
-    mapOf(
-        "run_id" to identity.runId,
-        "started_at" to Timestamp.from(startedAt),
-        "source_path" to result.sourcePath,
-        "target_path" to result.targetPath,
-        "attempts_used" to result.attemptsUsed,
-        "error" to (result.error ?: "unknown"),
-    )
-
-private fun storageType(config: StorageConfig): String =
-    when (config) {
-        is S3Config -> "s3"
-        is HdfsConfig -> "hdfs"
-    }
+internal fun createTableSql(
+    table: String,
+    schema: StructType,
+): String =
+    """
+    CREATE TABLE IF NOT EXISTS $table (${schema.toDDL()})
+    USING iceberg
+    PARTITIONED BY (days(started_at))
+    """.trimIndent()

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ParserTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ParserTest.kt
@@ -150,6 +150,61 @@ class ParserTest {
     }
 
     @Test
+    fun `parse stats block binds recording settings`() {
+        val json =
+            """
+            {
+              "source": {
+                "type": "s3",
+                "bucket": "source-bucket",
+                "accessKey": "access123",
+                "secretKey": "secret456"
+              },
+              "target": {
+                "type": "s3",
+                "bucket": "target-bucket",
+                "accessKey": "access789",
+                "secretKey": "secret012"
+              },
+              "stats": { "enabled": false, "database": "other.db", "maxFailureRows": 0 }
+            }
+            """.trimIndent()
+
+        val stats = Parser.parse(json).stats
+
+        assertEquals(false, stats.enabled)
+        assertEquals("other.db", stats.database)
+        assertEquals(0, stats.maxFailureRows)
+    }
+
+    @Test
+    fun `parse config without stats block records to the system database`() {
+        val json =
+            """
+            {
+              "source": {
+                "type": "s3",
+                "bucket": "source-bucket",
+                "accessKey": "access123",
+                "secretKey": "secret456"
+              },
+              "target": {
+                "type": "s3",
+                "bucket": "target-bucket",
+                "accessKey": "access789",
+                "secretKey": "secret012"
+              }
+            }
+            """.trimIndent()
+
+        val stats = Parser.parse(json).stats
+
+        assertEquals(true, stats.enabled)
+        assertEquals("spark_catalog.iomete_system_db", stats.database)
+        assertEquals(1000, stats.maxFailureRows)
+    }
+
+    @Test
     fun `parse S3-to-HDFS config binds HdfsConfig target`() {
         val json =
             """

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
@@ -4,6 +4,7 @@ import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.CopyConfig
 import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
+import com.iomete.backup.config.StatsConfig
 import org.junit.jupiter.api.Test
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -174,6 +175,50 @@ class ValidatorTest {
 
         assertIs<ValidationResult.Invalid>(result)
         assertTrue(result.errors.any { it.contains("authentication") && it.contains("target") })
+    }
+
+    @Test
+    fun `a stats database that is not a dotted identifier fails validation`() {
+        listOf(
+            "spark_catalog.iomete_system_db; DROP TABLE x",
+            "spark_catalog.`weird name`",
+            "",
+            "1bad.db",
+            "trailing.",
+        ).forEach { database ->
+            val result =
+                Validator.validate(
+                    ApplicationConfig(source = s3Config(), target = s3Config(), stats = StatsConfig(database = database)),
+                )
+
+            assertIs<ValidationResult.Invalid>(result, "expected '$database' to be rejected")
+            assertTrue(result.errors.any { it.contains("database") })
+        }
+    }
+
+    @Test
+    fun `a dotted stats database passes validation`() {
+        val result =
+            Validator.validate(
+                ApplicationConfig(
+                    source = s3Config(),
+                    target = s3Config(),
+                    stats = StatsConfig(database = "other_catalog.other_db"),
+                ),
+            )
+
+        assertIs<ValidationResult.Valid>(result)
+    }
+
+    @Test
+    fun `a negative failure row cap fails validation`() {
+        val result =
+            Validator.validate(
+                ApplicationConfig(source = s3Config(), target = s3Config(), stats = StatsConfig(maxFailureRows = -1)),
+            )
+
+        assertIs<ValidationResult.Invalid>(result)
+        assertTrue(result.errors.any { it.contains("maxFailureRows") })
     }
 
     @Test

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
@@ -178,7 +178,7 @@ class ValidatorTest {
     }
 
     @Test
-    fun `a stats database that is not a dotted identifier fails validation`() {
+    fun `a stats database that is not a valid identifier fails validation`() {
         listOf(
             "spark_catalog.iomete_system_db; DROP TABLE x",
             "spark_catalog.`weird name`",
@@ -197,17 +197,15 @@ class ValidatorTest {
     }
 
     @Test
-    fun `a dotted stats database passes validation`() {
-        val result =
-            Validator.validate(
-                ApplicationConfig(
-                    source = s3Config(),
-                    target = s3Config(),
-                    stats = StatsConfig(database = "other_catalog.other_db"),
-                ),
-            )
+    fun `a stats database passes validation with or without a catalog`() {
+        listOf("other_catalog.other_db", "other_db").forEach { database ->
+            val result =
+                Validator.validate(
+                    ApplicationConfig(source = s3Config(), target = s3Config(), stats = StatsConfig(database = database)),
+                )
 
-        assertIs<ValidationResult.Valid>(result)
+            assertIs<ValidationResult.Valid>(result, "expected '$database' to be accepted")
+        }
     }
 
     @Test

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/CopyAggregateFoldTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/CopyAggregateFoldTest.kt
@@ -12,7 +12,7 @@ class CopyAggregateFoldTest {
 
     @Test
     fun `empty aggregate is zero`() {
-        val agg = CopyAggregate()
+        val agg = CopyAggregate(maxSampledFailures = 1000)
         assertEquals(0, agg.successCount)
         assertEquals(0, agg.failureCount)
         assertEquals(0L, agg.totalBytesCopied)
@@ -21,7 +21,7 @@ class CopyAggregateFoldTest {
 
     @Test
     fun `add accumulates success counts and bytes without recording failures`() {
-        val agg = listOf(success(10), success(20), success(30)).fold(CopyAggregate()) { a, r -> a.add(r) }
+        val agg = listOf(success(10), success(20), success(30)).fold(CopyAggregate(maxSampledFailures = 1000)) { a, r -> a.add(r) }
         assertEquals(3, agg.successCount)
         assertEquals(0, agg.failureCount)
         assertEquals(60L, agg.totalBytesCopied)
@@ -30,7 +30,7 @@ class CopyAggregateFoldTest {
 
     @Test
     fun `add caps sampled failures within a single partition while counting all`() {
-        val agg = (1..1500).fold(CopyAggregate()) { a, i -> a.add(failure("f$i")) }
+        val agg = (1..1500).fold(CopyAggregate(maxSampledFailures = 1000)) { a, i -> a.add(failure("f$i")) }
         assertEquals(1500, agg.failureCount)
         assertEquals(1000, agg.failures.size)
         assertEquals("f1", agg.failures.first().sourcePath)
@@ -39,8 +39,8 @@ class CopyAggregateFoldTest {
 
     @Test
     fun `merge re-caps concatenated failures and sums counts`() {
-        val left = (1..700).fold(CopyAggregate()) { a, i -> a.add(failure("l$i")) }
-        val right = (1..700).fold(CopyAggregate()) { a, i -> a.add(failure("r$i")) }
+        val left = (1..700).fold(CopyAggregate(maxSampledFailures = 1000)) { a, i -> a.add(failure("l$i")) }
+        val right = (1..700).fold(CopyAggregate(maxSampledFailures = 1000)) { a, i -> a.add(failure("r$i")) }
 
         val merged = left.merge(right)
 

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/CopyAggregateTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/CopyAggregateTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CopyAggregateTest {
@@ -36,7 +38,7 @@ class CopyAggregateTest {
         val results = listOf(success("a", 10), success("b", 20), failure("c"), success("d", 30), failure("e"))
         val rdd = jsc.parallelize(results, 3)
 
-        val agg = aggregateCopyResults(rdd)
+        val agg = aggregateCopyResults(rdd, maxSampledFailures = 1000)
 
         assertEquals(3, agg.successCount)
         assertEquals(2, agg.failureCount)
@@ -49,10 +51,36 @@ class CopyAggregateTest {
         val results = (1..1500).map { failure("f$it") }
         val rdd = jsc.parallelize(results, 4)
 
-        val agg = aggregateCopyResults(rdd)
+        val agg = aggregateCopyResults(rdd, maxSampledFailures = 1000)
 
         assertEquals(0, agg.successCount)
         assertEquals(1500, agg.failureCount)
         assertEquals(1000, agg.failures.size)
+        assertTrue(agg.failuresTruncated)
+    }
+
+    @Test
+    fun `the failure cap is configurable and zero keeps none`() {
+        val rdd = jsc.parallelize((1..20).map { failure("f$it") }, 4)
+
+        val capped = aggregateCopyResults(rdd, maxSampledFailures = 5)
+        assertEquals(20, capped.failureCount)
+        assertEquals(5, capped.failures.size)
+        assertTrue(capped.failuresTruncated)
+
+        val none = aggregateCopyResults(rdd, maxSampledFailures = 0)
+        assertEquals(20, none.failureCount)
+        assertEquals(0, none.failures.size)
+        assertTrue(none.failuresTruncated)
+    }
+
+    @Test
+    fun `counts the attempts beyond the first, and reports no truncation when every failure fits`() {
+        val rdd = jsc.parallelize(listOf(success("a", 10), failure("b"), success("c", 20)), 2)
+
+        val agg = aggregateCopyResults(rdd, maxSampledFailures = 1000)
+
+        assertEquals(2L, agg.retriesUsed)
+        assertFalse(agg.failuresTruncated)
     }
 }

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/FileCopierTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/copy/internal/FileCopierTest.kt
@@ -17,6 +17,8 @@ import org.apache.hadoop.fs.FSDataOutputStream
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.Path
+import org.apache.spark.SparkConf
+import org.apache.spark.api.java.JavaSparkContext
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -398,28 +400,32 @@ class FileCopierTest {
 
     @Test
     fun `copier is serializable`() {
-        val copier =
-            FileCopier(
-                sourceConfig = dummyConfig,
-                targetConfig = dummyConfig,
-                sourceRoot = "s3a://source/root",
-                targetRoot = "s3a://target/root",
-            )
+        // Registered timers: Spark refuses to serialize an accumulator the driver never registered.
+        JavaSparkContext(SparkConf().setAppName("file-copier-serialization").setMaster("local[1]")).use { jsc ->
+            val copier =
+                FileCopier(
+                    sourceConfig = dummyConfig,
+                    targetConfig = dummyConfig,
+                    sourceRoot = "s3a://source/root",
+                    targetRoot = "s3a://target/root",
+                    timers = CopyTimers.register(jsc.sc()),
+                )
 
-        // Serialize and deserialize
-        val baos = ByteArrayOutputStream()
-        ObjectOutputStream(baos).use { it.writeObject(copier) }
-        val bytes = baos.toByteArray()
+            // Serialize and deserialize
+            val baos = ByteArrayOutputStream()
+            ObjectOutputStream(baos).use { it.writeObject(copier) }
+            val bytes = baos.toByteArray()
 
-        val deserialized =
-            ObjectInputStream(
-                ByteArrayInputStream(bytes),
-            ).use { it.readObject() as FileCopier }
+            val deserialized =
+                ObjectInputStream(
+                    ByteArrayInputStream(bytes),
+                ).use { it.readObject() as FileCopier }
 
-        // The deserialized copier should be usable (logger re-created lazily)
-        // We can't easily test copy on a deserialized instance without real S3,
-        // but at least verify it deserializes without error
-        assertTrue(bytes.isNotEmpty())
+            // The deserialized copier should be usable (logger re-created lazily)
+            // We can't easily test copy on a deserialized instance without real S3,
+            // but at least verify it deserializes without error
+            assertTrue(bytes.isNotEmpty())
+        }
     }
 
     @Test

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/stats/RunStatsTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/stats/RunStatsTest.kt
@@ -1,0 +1,103 @@
+package com.iomete.backup.stats
+
+import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.CopyConfig
+import com.iomete.backup.config.HdfsConfig
+import com.iomete.backup.config.S3Config
+import com.iomete.backup.copy.CopyJobSummary
+import com.iomete.backup.copy.CopyResult
+import com.iomete.backup.copy.CopyStats
+import com.iomete.backup.copy.ExecutorTimings
+import org.junit.jupiter.api.Test
+import java.sql.Timestamp
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class RunStatsTest {
+    private val startedAt = Instant.parse("2026-01-02T03:04:05Z")
+    private val identity = RunIdentity(runId = "run-1", jobId = "job-1", startedBy = null)
+
+    private val config =
+        ApplicationConfig(
+            source = S3Config(bucket = "src", prefix = "in", accessKey = "k", secretKey = "s"),
+            target = HdfsConfig(namenode = "nn:8020", path = "out", user = "u"),
+            copy = CopyConfig(bytesPerTask = 42, filesPerTask = 7, skipIdentical = false, maxBandwidthMbPerSec = 12.5),
+        )
+
+    private fun finishedProgress() =
+        RunProgress().apply {
+            filesListed = 10
+            dirsListed = 2
+            bytesSource = 5000
+            sourceListingMs = 111
+            summary =
+                CopyJobSummary(
+                    totalEntries = 10,
+                    successCount = 8,
+                    failureCount = 1,
+                    skippedCount = 1,
+                    totalBytesCopied = 4000,
+                    skippedBytes = 500,
+                    errors = emptyList(),
+                )
+            copy =
+                CopyStats(
+                    targetListingMs = 22,
+                    planningMs = 33,
+                    copyMs = 44,
+                    dirCreateMs = 55,
+                    taskCount = 3,
+                    largestFileBytes = 3000,
+                    filesCopied = 6,
+                    dirsCreated = 2,
+                    retriesUsed = 4,
+                    failuresTruncated = true,
+                    executor =
+                        ExecutorTimings(
+                            copyTaskMs = 100,
+                            fsInitMs = 10,
+                            sourceReadMs = 20,
+                            targetWriteMs = 30,
+                            throttleWaitMs = 40,
+                            verifyMs = 5,
+                            commitMs = 6,
+                            retrySleepMs = 7,
+                        ),
+                )
+        }
+
+    @Test
+    fun `every row the code builds fits the table it is written to`() {
+        rowOf(RUNS_SCHEMA, runRow(identity, config, startedAt, null, RunStatus.RUNNING, null, RunProgress()))
+        rowOf(RUNS_SCHEMA, runRow(identity, config, startedAt, startedAt, RunStatus.SUCCEEDED, null, finishedProgress()))
+        rowOf(FILE_FAILURES_SCHEMA, fileFailureRow(identity, startedAt, CopyResult("a", "b", success = false)))
+
+        assertFailsWith<IllegalArgumentException> { rowOf(RUNS_SCHEMA, mapOf("run_id" to "x")) }
+        assertFailsWith<IllegalArgumentException> {
+            rowOf(FILE_FAILURES_SCHEMA, fileFailureRow(identity, startedAt, CopyResult("a", "b", false)) + ("attempts_used" to 1L))
+        }
+    }
+
+    @Test
+    fun `a row derives what it cannot copy straight through`() {
+        val row = runRow(identity, config, startedAt, null, RunStatus.RUNNING, null, finishedProgress())
+
+        assertEquals("s3", row["source_type"])
+        assertEquals("s3a://src/in", row["source_uri"])
+        assertEquals("hdfs", row["target_type"])
+        assertEquals("hdfs://nn:8020/out", row["target_uri"])
+        assertEquals(Timestamp.from(startedAt), row["started_at"])
+        assertEquals(1L, row["files_failed"])
+
+        val failure = fileFailureRow(identity, startedAt, CopyResult("a", "b", success = false))
+        assertEquals("unknown", failure["error"])
+    }
+
+    @Test
+    fun `every column tells an operator what it holds`() {
+        assertTrue(RUNS_SCHEMA.fields().all { it.getComment().isDefined }, "DESCRIBE TABLE is where an operator looks")
+        assertTrue(FILE_FAILURES_SCHEMA.fields().all { it.getComment().isDefined })
+    }
+}

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/stats/StatsRecorderTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/stats/StatsRecorderTest.kt
@@ -1,0 +1,55 @@
+package com.iomete.backup.stats
+
+import com.iomete.backup.config.ApplicationConfig
+import com.iomete.backup.config.S3Config
+import com.iomete.backup.config.StatsConfig
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.apache.spark.sql.RuntimeConfig
+import org.apache.spark.sql.SparkSession
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/** A catalog problem is the backup's problem only if it is allowed to become one. It is not. */
+class StatsRecorderTest {
+    private val config =
+        ApplicationConfig(
+            source = S3Config(bucket = "src", accessKey = "k", secretKey = "s"),
+            target = S3Config(bucket = "dst", accessKey = "k", secretKey = "s"),
+        )
+
+    private fun sparkThatFails(): SparkSession {
+        val runtimeConfig = mockk<RuntimeConfig>()
+        every { runtimeConfig.get("spark.app.name") } returns "run-1"
+
+        val spark = mockk<SparkSession>()
+        every { spark.conf() } returns runtimeConfig
+        every { spark.sql(any<String>()) } throws IllegalStateException("catalog is down")
+        every { spark.createDataFrame(any<List<*>>(), any()) } throws IllegalStateException("catalog is down")
+
+        return spark
+    }
+
+    @Test
+    fun `a stats write that throws is swallowed`() {
+        val spark = sparkThatFails()
+        val recorder = StatsRecorder(spark, config)
+
+        recorder.claim(Instant.now())
+        recorder.finalise(Instant.now(), RunProgress(), null)
+
+        verify(atLeast = 1) { spark.sql(any<String>()) }
+    }
+
+    @Test
+    fun `recording disabled touches no table`() {
+        val spark = sparkThatFails()
+        val recorder = StatsRecorder(spark, config.copy(stats = StatsConfig(enabled = false)))
+
+        recorder.claim(Instant.now())
+        recorder.finalise(Instant.now(), RunProgress(), RuntimeException("boom"))
+
+        verify(exactly = 0) { spark.sql(any<String>()) }
+    }
+}

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/stats/internal/RowMappingTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/stats/internal/RowMappingTest.kt
@@ -1,4 +1,4 @@
-package com.iomete.backup.stats
+package com.iomete.backup.stats.internal
 
 import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.CopyConfig
@@ -8,6 +8,8 @@ import com.iomete.backup.copy.CopyJobSummary
 import com.iomete.backup.copy.CopyResult
 import com.iomete.backup.copy.CopyStats
 import com.iomete.backup.copy.ExecutorTimings
+import com.iomete.backup.stats.RunProgress
+import com.iomete.backup.stats.RunStatus
 import org.junit.jupiter.api.Test
 import java.sql.Timestamp
 import java.time.Instant
@@ -15,7 +17,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class RunStatsTest {
+class RowMappingTest {
     private val startedAt = Instant.parse("2026-01-02T03:04:05Z")
     private val identity = RunIdentity(runId = "run-1", jobId = "job-1", startedBy = null)
 


### PR DESCRIPTION
### Summary

Records every backup run in two Iceberg tables under `spark_catalog.iomete_system_db`: one row per run with status, counts, byte totals and a full time breakdown, and a companion table holding the entries a run failed to copy. Operators can now answer after the fact whether a scheduled backup succeeded, what it moved, and where its time went, without the driver logs.

Closes [DEL-369](https://linear.app/iomete/issue/DEL-369/per-run-stats-table-for-backup-run-tracking).

### Context

A run was observable only through driver logs, and those disappear with the pod. Nobody could say the next morning whether last night's backup succeeded, how much data it moved, or whether it is getting slower run over run. When a run was slow there was no way to separate listing from copying, or a slow source from a slow target. This lands the evidence base that DEL-370's throughput target needs, and the executor breakdown that decides whether DEL-359 and DEL-390 are worth doing.

### Implementation

- **Claim then finalise.** `BackupJob.run` appends a `RUNNING` row before source enumeration and merges the final state into it on the way out, in both the success and failure paths. A row still `RUNNING` long after `started_at` is therefore a run whose driver died, which is a signal nothing else provides. The merge joins on `run_id` alone: a driver restarted by the operator reuses the CR name but not the timestamp, so including `started_at` in the join would insert a second row and strand the first in `RUNNING` forever. `WHEN NOT MATCHED THEN INSERT` makes the finalise self-healing when the claim failed.
- **Best-effort writes.** `StatsRecorder` swallows and logs everything it throws, including `Error`, since a missing Iceberg runtime arrives as one. A backup that copied every byte is never failed by a problem recording its own history. `InterruptedException` re-sets the interrupt flag rather than being logged.
- **One schema definition.** `RUNS_SCHEMA` and `FILE_FAILURES_SCHEMA` drive both `CREATE TABLE` (via `StructType.toDDL()`) and the row DataFrames, so columns and their `COMMENT`s are declared once. `rowOf` validates key set and value types on the driver, because Spark otherwise rejects a mistyped value on the executors, far from the mapping that produced it.
- **Timing.** Driver phases (source listing, target listing, planning, copy, directory creation) are measured around the existing calls in `BackupJob` and `CopyJobRunner`. Storage-side timings are `LongAccumulator`s registered on the driver and threaded through `FileCopier` around each filesystem build, read, throttle wait, write, length check, commit and retry sleep. These can double-count under task retry or speculation, so files and bytes still come from `CopyAggregate`; the accumulators are for diagnosis only. `copy_task_ms / copy_ms` gives average copy concurrency without needing to know the cluster size.
- **Configuration.** New `stats` block with `enabled`, `database` and `maxFailureRows`, all defaulted so existing configs are unaffected. `database` reaches `CREATE TABLE` as SQL text, so `Validator` rejects anything that is not a dotted identifier before any statement runs. `CopyAggregate`'s hardcoded `MAX_SAMPLED_FAILURES` becomes `stats.maxFailureRows`, threaded through so the cap still applies on the executors; `files_failed` stays the true count and `failures_truncated` flags when the cap bit.
- **Tests.** `StatsIntegrationTest` runs the real job against an Iceberg Hadoop catalog in the build directory and asserts on what an operator would query: one row per run, matching counts and bytes, populated phase clocks, a `FAILED` row with its failure rows for an unwritable target, and that a throwing stats write leaves the backup's outcome alone. Each case uses its own session so it gets a distinct `spark.app.name`, which is where `run_id` comes from. The three pre-existing integration classes now disable stats explicitly, since the harness has no Iceberg catalog at the default database.
- **Docs.** `docs/run-stats.md` is written for the operator: a column reference, ready-to-run queries for checking a run, spotting an abandoned one and reading throughput, and a troubleshooting table mapping each signal to its likely cause. The README gains a "Run history" section covering the `stats` block.
