### PR TITLE
fix(ci): point repo maintenance at the shared public workflow

### DIFF
--- a/.github/workflows/repo-maintenance.yml
+++ b/.github/workflows/repo-maintenance.yml
@@ -12,4 +12,6 @@ permissions:
 
 jobs:
   stale:
-    uses: iomete/infra/.github/workflows/repo-maintenance.yml@main
+    uses: iomete/.github/.github/workflows/repo-maintenance.yml@main
+    with:
+      runs-on: ubuntu-latest


### PR DESCRIPTION
- The daily stale pull request cleanup has never actually run in this repository. It was shared from a private location, and GitHub does not allow public repositories to use it from there.
- This repository now points at a public shared location and uses GitHub hosted runners, which fixes the daily failure.
- Behaviour once it runs: pull requests inactive for 30 days get a warning, and close 7 days later unless someone comments, pushes, or adds the keep-open label. Issues are untouched.
- Depends on iomete/.github#3, which should be merged first.
