### PR TITLE
Revert Spark SQL upgrade to 3.5.9

### DIFF
--- a/iomete-lakehouse-backup/gradle.properties
+++ b/iomete-lakehouse-backup/gradle.properties
@@ -6,7 +6,7 @@ kotlin.code.style=official
 
 # Single source of truth (build.gradle.kts + Makefile derive from this).
 projectVersion=1.3.0
-sparkVersion=3.5.9
+sparkVersion=3.5.7
 sparkImageRevision=v2
 # Must match the iomete/spark base image
 hadoopAwsVersion=3.5.0


### PR DESCRIPTION
## Summary

Downgrade Apache Spark from 3.5.9 to 3.5.7.

## Context

Reverts commit `b1ebf605f7234f6f36b0b02fc17b16580cdb059a`, which upgraded Spark SQL to 3.5.9.

## Implementation

Update `sparkVersion` in `gradle.properties` from `3.5.9` to `3.5.7`.