### PR TITLE
chore: stop Renovate from bumping Spark in all jobs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -72,6 +72,16 @@
       "allowedVersions": "<3.6"
     },
     {
+      "description": "Don't bump Spark in the lakehouse backup job - sparkVersion in its gradle.properties is the single source of truth for both the jars and the iomete/spark base image tag it runs on, so a bump here silently mismatches the runtime (see the revert of #277)",
+      "matchFileNames": [
+        "iomete-lakehouse-backup/**"
+      ],
+      "matchPackageNames": [
+        "/^org\\.apache\\.spark:/"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Don't touch antlr4-runtime - the forced version has to match what Spark pulls in, otherwise SQL parsing breaks at runtime",
       "matchPackageNames": [
         "org.antlr:antlr4-runtime"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,21 +65,19 @@
       "allowedVersions": "<2.13"
     },
     {
-      "description": "Keep Spark on the 3.5 line - these jobs run inside the iomete Spark 3.5 images",
+      "description": "Don't bump Spark in any job - the Spark version has to match the iomete Spark image the job runs on, so it can only move together with that image (see the revert of #277). pyspark is matched exactly so the pyspark-iomete client is still updated.",
+      "matchPackageNames": [
+        "/^org\\.apache\\.spark:/",
+        "pyspark"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Keep Spark on the 3.5 line - the rule above already blocks routine bumps, this stops a forced security update from jumping the JVM jobs to Spark 4",
       "matchPackageNames": [
         "/^org\\.apache\\.spark:/"
       ],
       "allowedVersions": "<3.6"
-    },
-    {
-      "description": "Don't bump Spark in the lakehouse backup job - sparkVersion in its gradle.properties is the single source of truth for both the jars and the iomete/spark base image tag it runs on, so a bump here silently mismatches the runtime (see the revert of #277)",
-      "matchFileNames": [
-        "iomete-lakehouse-backup/**"
-      ],
-      "matchPackageNames": [
-        "/^org\\.apache\\.spark:/"
-      ],
-      "enabled": false
     },
     {
       "description": "Don't touch antlr4-runtime - the forced version has to match what Spark pulls in, otherwise SQL parsing breaks at runtime",

--- a/iomete-lakehouse-backup/gradle.properties
+++ b/iomete-lakehouse-backup/gradle.properties
@@ -6,7 +6,7 @@ kotlin.code.style=official
 
 # Single source of truth (build.gradle.kts + Makefile derive from this).
 projectVersion=1.3.0
-# Pinned to the iomete/spark base image - bump only together with the image (Renovate is disabled for it).
+# Pinned to the iomete/spark base image - bump only together with the image (Renovate is disabled for Spark).
 sparkVersion=3.5.7
 sparkImageRevision=v2
 # Must match the iomete/spark base image

--- a/iomete-lakehouse-backup/gradle.properties
+++ b/iomete-lakehouse-backup/gradle.properties
@@ -6,6 +6,7 @@ kotlin.code.style=official
 
 # Single source of truth (build.gradle.kts + Makefile derive from this).
 projectVersion=1.3.0
+# Pinned to the iomete/spark base image - bump only together with the image (Renovate is disabled for it).
 sparkVersion=3.5.7
 sparkImageRevision=v2
 # Must match the iomete/spark base image


### PR DESCRIPTION
- Every job's Spark version has to match the Spark image it actually runs on, so Spark can't be bumped on its own. A recent automated bump had to be reverted for that reason.
- Renovate will no longer open Spark update PRs for any of the jobs, on either the Java or the Python side. Spark now moves only when someone moves it together with the image.
- Security fixes still come through, and are still held to the Spark 3.5 line for the Java jobs.
- The iomete PySpark client keeps getting updates as before.
