### PR TITLE
fix(PLA-953): verify released images are really locked

### DIFF
--- a/.github/workflows/lakehouse_backup_release.yml
+++ b/.github/workflows/lakehouse_backup_release.yml
@@ -85,11 +85,8 @@ jobs:
               exit 1
             fi
             make docker-push-tag extra_tag=$sha
-            for t in "$tag" "$sha"; do
-              az acr repository update --name ${{ secrets.ACR_NAME }} \
-                --image iomete/iomete-lakehouse-backup:$t \
-                --write-enabled false --delete-enabled false
-            done
+            ../scripts/lock-acr-tag.sh "${{ secrets.ACR_NAME }}" \
+              iomete/iomete-lakehouse-backup "$tag" "$sha"
           else
             # Branch test build: single mutable branch-name tag.
             branch_tag=$(echo "$REF" | tr '/' '-')

--- a/.github/workflows/lakehouse_backup_release.yml
+++ b/.github/workflows/lakehouse_backup_release.yml
@@ -69,6 +69,7 @@ jobs:
         run: az acr login --name ${{ secrets.ACR_NAME }}
 
       - name: Build and push image
+        id: push
         env:
           REF: ${{ github.ref_name }}
         run: |
@@ -80,15 +81,25 @@ jobs:
               echo "::error::projectVersion not found in gradle.properties"
               exit 1
             fi
-            if az acr repository show --name ${{ secrets.ACR_NAME }} --image iomete/iomete-lakehouse-backup:$tag >/dev/null 2>&1; then
+            if az acr repository show --name ${{ vars.ACR_NAME }} --image ${{ vars.ACR_NAMESPACE }}/iomete-lakehouse-backup:$tag >/dev/null 2>&1; then
               echo "::error::version $tag already published — bump projectVersion in gradle.properties"
               exit 1
             fi
             make docker-push-tag extra_tag=$sha
-            ../scripts/lock-acr-tag.sh "${{ secrets.ACR_NAME }}" \
-              iomete/iomete-lakehouse-backup "$tag" "$sha"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
           else
             # Branch test build: single mutable branch-name tag.
             branch_tag=$(echo "$REF" | tr '/' '-')
             make docker-push tag="$branch_tag"
           fi
+
+      # Released tags only. The step confirms the lock really took, a lock set right
+      # after a push can be reset by the registry moments later.
+      - name: Lock the released tags
+        if: ${{ steps.push.outputs.tag != '' }}
+        uses: iomete/.github/actions/acr/mark-tag-immutable@main
+        with:
+          acr_name: ${{ vars.ACR_NAME }}
+          repository: ${{ vars.ACR_NAMESPACE }}/iomete-lakehouse-backup
+          tag: ${{ steps.push.outputs.tag }} ${{ steps.push.outputs.sha }}

--- a/.github/workflows/lakehouse_backup_release.yml
+++ b/.github/workflows/lakehouse_backup_release.yml
@@ -81,7 +81,7 @@ jobs:
               echo "::error::projectVersion not found in gradle.properties"
               exit 1
             fi
-            if az acr repository show --name ${{ vars.ACR_NAME }} --image ${{ vars.ACR_NAMESPACE }}/iomete-lakehouse-backup:$tag >/dev/null 2>&1; then
+            if az acr repository show --name ${{ secrets.ACR_NAME }} --image ${{ vars.ACR_NAMESPACE }}/iomete-lakehouse-backup:$tag >/dev/null 2>&1; then
               echo "::error::version $tag already published — bump projectVersion in gradle.properties"
               exit 1
             fi
@@ -100,6 +100,6 @@ jobs:
         if: ${{ steps.push.outputs.tag != '' }}
         uses: iomete/.github/actions/acr/mark-tag-immutable@main
         with:
-          acr_name: ${{ vars.ACR_NAME }}
+          acr_name: ${{ secrets.ACR_NAME }}
           repository: ${{ vars.ACR_NAMESPACE }}/iomete-lakehouse-backup
           tag: ${{ steps.push.outputs.tag }} ${{ steps.push.outputs.sha }}

--- a/debezium-server-iomete/Makefile
+++ b/debezium-server-iomete/Makefile
@@ -11,6 +11,6 @@ docker-push:
 	# Run this for one time: docker buildx create --use
 	az acr login --name iomete
 	docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t ${docker_image}:${docker_tag} . --sbom=true --provenance=true
-	az acr repository update --name iomete --image iomete/debezium-server-iomete:${docker_tag} --write-enabled false --delete-enabled false
+	../scripts/lock-acr-tag.sh iomete iomete/debezium-server-iomete ${docker_tag}
 	@echo ${docker_image}
 	@echo ${docker_tag}

--- a/debezium-server-iomete/Makefile
+++ b/debezium-server-iomete/Makefile
@@ -11,6 +11,6 @@ docker-push:
 	# Run this for one time: docker buildx create --use
 	az acr login --name iomete
 	docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t ${docker_image}:${docker_tag} . --sbom=true --provenance=true
-	../scripts/lock-acr-tag.sh iomete iomete/debezium-server-iomete ${docker_tag}
+	../scripts/lock-acr-tag.sh ${docker_image}:${docker_tag}
 	@echo ${docker_image}
 	@echo ${docker_tag}

--- a/iomete-mysql-sync/Makefile
+++ b/iomete-mysql-sync/Makefile
@@ -14,6 +14,6 @@ docker-push:
 	# Run this for one time: docker buildx create --use
 	az acr login --name iomete
 	docker buildx build --platform linux/amd64,linux/arm64 --push -f docker/Dockerfile -t ${docker_image}:${docker_tag} . --sbom=true --provenance=true
-	../scripts/lock-acr-tag.sh iomete iomete/iomete_mysql_sync ${docker_tag}
+	../scripts/lock-acr-tag.sh ${docker_image}:${docker_tag}
 	@echo ${docker_image}
 	@echo ${docker_tag}

--- a/iomete-mysql-sync/Makefile
+++ b/iomete-mysql-sync/Makefile
@@ -14,6 +14,6 @@ docker-push:
 	# Run this for one time: docker buildx create --use
 	az acr login --name iomete
 	docker buildx build --platform linux/amd64,linux/arm64 --push -f docker/Dockerfile -t ${docker_image}:${docker_tag} . --sbom=true --provenance=true
-	az acr repository update --name iomete --image iomete/iomete_mysql_sync:${docker_tag} --write-enabled false --delete-enabled false
+	../scripts/lock-acr-tag.sh iomete iomete/iomete_mysql_sync ${docker_tag}
 	@echo ${docker_image}
 	@echo ${docker_tag}

--- a/scripts/lock-acr-tag.sh
+++ b/scripts/lock-acr-tag.sh
@@ -1,25 +1,24 @@
 #!/usr/bin/env bash
-# Locks ACR image tags against overwrite and deletion, and verifies the lock stuck.
+# Locks pushed image tags against overwrite and deletion, and verifies the lock stuck.
+# For the manual make release targets. CI uses the shared step in iomete/.github.
 #
-# ACR can rewrite tag metadata for a few seconds after a push, which silently drops
-# a lock applied in that window, so settle first and read the attribute back instead
-# of trusting the update call's own output.
+# The registry can rewrite tag metadata for a few seconds after a push, which silently
+# drops a lock applied in that window, so settle first and read the attribute back
+# instead of trusting the update call's own output.
 #
-# usage: scripts/lock-acr-tag.sh <acr-name> <repository> <tag> [tag...]
+# usage: scripts/lock-acr-tag.sh <registry-host>/<repository>:<tag> [more...]
 set -euo pipefail
 
 SETTLE_SECONDS=${LOCK_SETTLE_SECONDS:-30}
 ATTEMPTS=${LOCK_ATTEMPTS:-5}
 
-acr=$1
-repository=$2
-shift 2
-
 echo "Settling ${SETTLE_SECONDS}s before locking"
 sleep "$SETTLE_SECONDS"
 
-for tag in "$@"; do
-  image="${repository}:${tag}"
+for reference in "$@"; do
+  acr=${reference%%/*}
+  acr=${acr%%.azurecr.io}
+  image=${reference#*/}
   locked=no
   for i in $(seq 1 "$ATTEMPTS"); do
     az acr repository update --name "$acr" --image "$image" \
@@ -38,7 +37,7 @@ for tag in "$@"; do
     sleep 10
   done
   if [ "$locked" != "yes" ]; then
-    echo "::error::lock did not stick on $image after $ATTEMPTS attempts"
+    echo "lock did not stick on $image after $ATTEMPTS attempts" >&2
     exit 1
   fi
 done

--- a/scripts/lock-acr-tag.sh
+++ b/scripts/lock-acr-tag.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Locks ACR image tags against overwrite and deletion, and verifies the lock stuck.
+#
+# ACR can rewrite tag metadata for a few seconds after a push, which silently drops
+# a lock applied in that window, so settle first and read the attribute back instead
+# of trusting the update call's own output.
+#
+# usage: scripts/lock-acr-tag.sh <acr-name> <repository> <tag> [tag...]
+set -euo pipefail
+
+SETTLE_SECONDS=${LOCK_SETTLE_SECONDS:-30}
+ATTEMPTS=${LOCK_ATTEMPTS:-5}
+
+acr=$1
+repository=$2
+shift 2
+
+echo "Settling ${SETTLE_SECONDS}s before locking"
+sleep "$SETTLE_SECONDS"
+
+for tag in "$@"; do
+  image="${repository}:${tag}"
+  locked=no
+  for i in $(seq 1 "$ATTEMPTS"); do
+    az acr repository update --name "$acr" --image "$image" \
+      --write-enabled false --delete-enabled false -o none
+    sleep 10
+    write=$(az acr repository show --name "$acr" --image "$image" \
+      --query changeableAttributes.writeEnabled -o tsv)
+    delete=$(az acr repository show --name "$acr" --image "$image" \
+      --query changeableAttributes.deleteEnabled -o tsv)
+    if [ "$write" = "false" ] && [ "$delete" = "false" ]; then
+      echo "$image locked (writeEnabled=$write, deleteEnabled=$delete) on attempt $i"
+      locked=yes
+      break
+    fi
+    echo "$image not locked on attempt $i (writeEnabled=$write, deleteEnabled=$delete), retrying"
+    sleep 10
+  done
+  if [ "$locked" != "yes" ]; then
+    echo "::error::lock did not stick on $image after $ATTEMPTS attempts"
+    exit 1
+  fi
+done


### PR DESCRIPTION
- The step that freezes a released image was reporting success while the freeze silently did not take effect.
- Uses the shared step, which waits for the image to settle, checks again afterwards, retries, and fails the release when the freeze does not hold.
- The manual release commands keep their own small script, since they run on a laptop rather than in a workflow.
- The registry and its namespace now come from repository variables instead of being written into the files.
- Needs the shared step merged first: https://github.com/iomete/.github/pull/4

Linear: https://linear.app/iomete/issue/PLA-953/released-images-are-not-actually-locked-the-lock-is-silently-reset
