### PR TITLE
[DEL-352] Add timestamped lakehouse backup folders

### DIFF
--- a/iomete-lakehouse-backup/README.md
+++ b/iomete-lakehouse-backup/README.md
@@ -83,6 +83,30 @@ adding a `copy` block, without deleting anything at the target:
 }
 ```
 
+### Keeping dated backups
+
+By default, every run writes to the same target root. To keep a separate backup
+folder for each hour, day, week, or month, set `targetTimestampFolder`:
+
+```json
+{
+  "copy": { "targetTimestampFolder": "daily" }
+}
+```
+
+| Value | Folder example |
+|---|---|
+| `hourly` | `2026-02-14-09` |
+| `daily` | `2026-02-14` |
+| `weekly` | `2026-W07` |
+| `monthly` | `2026-02` |
+
+Folder names use the run start time in UTC. Runs started in the same period use
+the same folder, so retries can skip files already copied there.
+
+> The job does not delete old backup folders or files removed from the source.
+> Configure a storage lifecycle rule or separate cleanup job for retention.
+
 ### Tuning copy concurrency and task size (advanced)
 
 Most backups can use the defaults below. Change them only when the run history

--- a/iomete-lakehouse-backup/gradle.properties
+++ b/iomete-lakehouse-backup/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx2048M
 kotlin.code.style=official
 
 # Single source of truth (build.gradle.kts + Makefile derive from this).
-projectVersion=1.3.0
+projectVersion=1.4.0
 # Pinned to the iomete/spark base image - bump only together with the image (Renovate is disabled for Spark).
 sparkVersion=3.5.7
 sparkImageRevision=v2

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/BackupJobIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.iomete.backup.integration
 import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.CopyConfig
 import com.iomete.backup.config.StorageConfig
+import com.iomete.backup.config.TimestampFolder
 import com.iomete.backup.integration.fixtures.assertMatches
 import com.iomete.backup.integration.fixtures.directoryExists
 import com.iomete.backup.integration.fixtures.fixture
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -183,6 +185,36 @@ class BackupJobIntegrationTest {
         val second = IntegrationHarness.runBackup(config)
         assertEquals(tree.size, second.successCount, "a disabled skip must copy everything again")
         assertEquals(0, second.skippedCount)
+    }
+
+    @Test
+    fun `a timestamp folder holds the run, and a re-run in the same period continues it`() {
+        val source = IntegrationHarness.freshBucket()
+        val target = IntegrationHarness.freshBucket()
+        val tree = mapOf("a.txt" to "alpha".toByteArray(), "nested/b.txt" to "bravo".toByteArray())
+        seedS3(source, tree)
+
+        val config =
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = IntegrationHarness.s3Config(target),
+                copy = CopyConfig(clockSkewToleranceMs = 0, targetTimestampFolder = "daily"),
+                stats = IntegrationHarness.STATS_DISABLED,
+            )
+
+        // MinIO truncates timestamps to whole seconds, so a copy taken within the same second as its
+        // source can be reported as older than it; wait the truncation out before the first run.
+        Thread.sleep(1_100)
+
+        val first = IntegrationHarness.runBackup(config)
+        assertEquals(tree.size, first.successCount)
+
+        val folder = TimestampFolder.folderName("daily", Instant.now())
+        assertEquals(tree.keys.map { "$folder/$it" }.toSet(), readS3(target).keys)
+
+        val second = IntegrationHarness.runBackup(config)
+        assertEquals(0, second.successCount, "a re-run in the same period must copy nothing again")
+        assertEquals(tree.size, second.skippedCount)
     }
 
     @Test

--- a/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/StatsIntegrationTest.kt
+++ b/iomete-lakehouse-backup/src/integrationTest/kotlin/com/iomete/backup/integration/StatsIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.iomete.backup.integration
 import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.CopyConfig
 import com.iomete.backup.config.StatsConfig
+import com.iomete.backup.config.TimestampFolder
 import com.iomete.backup.integration.fixtures.seedS3
 import com.iomete.backup.integration.harness.IntegrationHarness
 import com.iomete.backup.stats.FILE_FAILURES_TABLE
@@ -10,6 +11,7 @@ import com.iomete.backup.stats.RUNS_TABLE
 import com.iomete.backup.stats.RunStatus
 import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -84,6 +86,27 @@ class StatsIntegrationTest {
         assertEquals(1, row.getAs<Int>("slots_per_executor"))
         assertEquals(CopyConfig().tasksPerSlot, row.getAs<Int>("tasks_per_slot"))
         assertTrue(row.getAs<Int>("max_files_in_task") > 0)
+    }
+
+    @Test
+    fun `the recorded target uri includes the timestamp folder the run wrote to`() {
+        val source = IntegrationHarness.freshBucket()
+        val target = IntegrationHarness.freshBucket()
+        seedS3(source, mapOf("a.txt" to "alpha".toByteArray()))
+
+        val runId = UUID.randomUUID().toString()
+        IntegrationHarness.runBackup(
+            ApplicationConfig(
+                source = IntegrationHarness.s3Config(source),
+                target = IntegrationHarness.s3Config(target),
+                copy = CopyConfig(targetTimestampFolder = "daily"),
+                stats = statsConfig,
+            ),
+            IntegrationHarness.runSession(runId),
+        )
+
+        val folder = TimestampFolder.folderName("daily", Instant.now())
+        assertEquals("s3a://$target/$folder", runRow(runId).getAs<String>("target_uri"))
     }
 
     @Test

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/BackupJob.kt
@@ -3,6 +3,7 @@ package com.iomete.backup
 import com.iomete.backup.config.ApplicationConfig
 import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.InternalConfig
+import com.iomete.backup.config.TimestampFolder
 import com.iomete.backup.copy.CopyJobRunner
 import com.iomete.backup.copy.CopyJobSummary
 import com.iomete.backup.fs.useFileLister
@@ -23,21 +24,32 @@ object BackupJob {
         config: ApplicationConfig,
         internalConfig: InternalConfig,
     ): CopyJobSummary {
-        val recorder = StatsRecorder(spark, config, internalConfig)
         val startedAt = Instant.now()
+        val resolvedConfig = resolveTarget(config, startedAt)
+        logger.info("Target root: {}", resolvedConfig.target.rootUri)
+
+        val recorder = StatsRecorder(spark, resolvedConfig, internalConfig)
         val progress = RunProgress()
 
         // Claimed before the source listing, which is the long single-threaded phase.
         recorder.claim(startedAt)
 
         try {
-            val summary = copy(spark, config, internalConfig, progress)
+            val summary = copy(spark, resolvedConfig, internalConfig, progress)
             recorder.finalise(startedAt, progress, null)
             return summary
         } catch (e: Throwable) {
             recorder.finalise(startedAt, progress, e)
             throw e
         }
+    }
+
+    private fun resolveTarget(
+        config: ApplicationConfig,
+        startedAt: Instant,
+    ): ApplicationConfig {
+        val granularity = config.copy.targetTimestampFolder ?: return config
+        return config.copy(target = config.target.withSubFolder(TimestampFolder.folderName(granularity, startedAt)))
     }
 
     private fun copy(

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/TimestampFolder.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/TimestampFolder.kt
@@ -1,0 +1,32 @@
+package com.iomete.backup.config
+
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.IsoFields
+
+object TimestampFolder {
+    private val FORMATTERS =
+        mapOf(
+            "hourly" to DateTimeFormatter.ofPattern("yyyy-MM-dd-HH"),
+            "daily" to DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+            "weekly" to
+                DateTimeFormatterBuilder()
+                    .appendValue(IsoFields.WEEK_BASED_YEAR, 4)
+                    .appendLiteral("-W")
+                    .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2)
+                    .toFormatter(),
+            "monthly" to DateTimeFormatter.ofPattern("yyyy-MM"),
+        ).mapValues { it.value.withZone(ZoneOffset.UTC) }
+
+    val supported: Set<String> get() = FORMATTERS.keys
+
+    fun folderName(
+        granularity: String,
+        at: Instant,
+    ): String =
+        requireNotNull(FORMATTERS[granularity]) {
+            "Unsupported timestamp folder granularity '$granularity'"
+        }.format(at)
+}

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/Types.kt
@@ -29,6 +29,8 @@ data class CopyConfig(
     val maxBytesPerTask: Long = 1024L * 1024 * 1024,
     // Aggregate ceiling across every executor, unlike DistCp's per-map -bandwidth. Null is uncapped.
     val maxBandwidthMbPerSec: Double? = null,
+    // Period granularity of the folder appended to the target root; null writes to the root itself.
+    val targetTimestampFolder: String? = null,
 )
 
 data class InternalConfig(
@@ -55,6 +57,8 @@ sealed class StorageConfig : java.io.Serializable {
     // Test seam only: Validator rejects it on the load path, so it is reachable
     // solely by callers driving BackupJob directly.
     abstract val hadoopOptions: Map<String, String>
+
+    abstract fun withSubFolder(name: String): StorageConfig
 }
 
 data class S3Config(
@@ -72,6 +76,8 @@ data class S3Config(
             val trimmedPrefix = prefix.trim('/')
             return if (trimmedPrefix.isEmpty()) "s3a://$bucket" else "s3a://$bucket/$trimmedPrefix"
         }
+
+    override fun withSubFolder(name: String): S3Config = copy(prefix = "${prefix.trim('/')}/$name".trimStart('/'))
 }
 
 data class HdfsConfig(
@@ -86,4 +92,6 @@ data class HdfsConfig(
             val trimmedPath = path.trim('/')
             return if (trimmedPath.isEmpty()) "hdfs://$namenode" else "hdfs://$namenode/$trimmedPath"
         }
+
+    override fun withSubFolder(name: String): HdfsConfig = copy(path = "${path.trim('/')}/$name".trimStart('/'))
 }

--- a/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
+++ b/iomete-lakehouse-backup/src/main/kotlin/com/iomete/backup/config/internal/Validator.kt
@@ -6,6 +6,7 @@ import com.iomete.backup.config.HdfsConfig
 import com.iomete.backup.config.S3Config
 import com.iomete.backup.config.StatsConfig
 import com.iomete.backup.config.StorageConfig
+import com.iomete.backup.config.TimestampFolder
 import org.apache.spark.SparkConf
 import org.slf4j.LoggerFactory
 
@@ -74,6 +75,15 @@ object Validator {
 
         if (copy.maxBytesPerTask < 1) {
             errors.add("copy: maxBytesPerTask must be at least 1 (got ${copy.maxBytesPerTask})")
+        }
+
+        copy.targetTimestampFolder?.let {
+            if (it !in TimestampFolder.supported) {
+                errors.add(
+                    "copy: targetTimestampFolder '$it' is not supported " +
+                        "(expected one of ${TimestampFolder.supported.joinToString(", ")})",
+                )
+            }
         }
     }
 

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/TimestampFolderTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/TimestampFolderTest.kt
@@ -1,0 +1,50 @@
+package com.iomete.backup.config
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TimestampFolderTest {
+    private val instant = Instant.parse("2026-02-14T09:35:12Z")
+
+    @Test
+    fun `each granularity has its own folder name`() {
+        assertEquals("2026-02-14-09", TimestampFolder.folderName("hourly", instant))
+        assertEquals("2026-02-14", TimestampFolder.folderName("daily", instant))
+        assertEquals("2026-W07", TimestampFolder.folderName("weekly", instant))
+        assertEquals("2026-02", TimestampFolder.folderName("monthly", instant))
+    }
+
+    @Test
+    fun `instants on either side of a period boundary land in different folders`() {
+        val before = Instant.parse("2026-02-15T23:59:59Z")
+        val after = Instant.parse("2026-02-16T00:00:00Z")
+
+        assertEquals("2026-02-15-23", TimestampFolder.folderName("hourly", before))
+        assertEquals("2026-02-16-00", TimestampFolder.folderName("hourly", after))
+        assertEquals("2026-02-15", TimestampFolder.folderName("daily", before))
+        assertEquals("2026-02-16", TimestampFolder.folderName("daily", after))
+        assertEquals("2026-W07", TimestampFolder.folderName("weekly", before))
+        assertEquals("2026-W08", TimestampFolder.folderName("weekly", after))
+    }
+
+    @Test
+    fun `the name is derived in UTC, not in the zone of the host`() {
+        // 2026-03-01T01:00+09:00 is still the previous day, month and week in UTC.
+        val instant = Instant.parse("2026-02-28T16:00:00Z")
+
+        assertEquals("2026-02-28", TimestampFolder.folderName("daily", instant))
+        assertEquals("2026-02", TimestampFolder.folderName("monthly", instant))
+    }
+
+    @Test
+    fun `a week folder keeps the ISO week-based year across a year boundary`() {
+        assertEquals("2026-W01", TimestampFolder.folderName("weekly", Instant.parse("2025-12-31T00:00:00Z")))
+    }
+
+    @Test
+    fun `an unknown granularity is rejected`() {
+        assertFailsWith<IllegalArgumentException> { TimestampFolder.folderName("yearly", instant) }
+    }
+}

--- a/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
+++ b/iomete-lakehouse-backup/src/test/kotlin/com/iomete/backup/config/internal/ValidatorTest.kt
@@ -268,4 +268,34 @@ class ValidatorTest {
             assertTrue(result.errors.any { it.contains(setting) }, "expected an error naming $setting")
         }
     }
+
+    @Test
+    fun `an unknown timestamp folder granularity fails validation and names the accepted values`() {
+        val config =
+            ApplicationConfig(
+                source = s3Config(),
+                target = s3Config(),
+                copy = CopyConfig(targetTimestampFolder = "yearly"),
+            )
+
+        val result = Validator.validate(config)
+
+        assertIs<ValidationResult.Invalid>(result)
+        val error = result.errors.single { it.contains("targetTimestampFolder") }
+        listOf("hourly", "daily", "weekly", "monthly").forEach {
+            assertTrue(error.contains(it), "expected the error to name $it")
+        }
+    }
+
+    @Test
+    fun `a known timestamp folder granularity passes validation`() {
+        val config =
+            ApplicationConfig(
+                source = s3Config(),
+                target = s3Config(),
+                copy = CopyConfig(targetTimestampFolder = "daily"),
+            )
+
+        assertIs<ValidationResult.Valid>(Validator.validate(config))
+    }
 }


### PR DESCRIPTION
## Summary

Add configurable hourly, daily, weekly, or monthly UTC timestamp folders to lakehouse backup targets.

## Context

Timestamped targets keep period-specific backup copies while allowing retries within the same period to reuse the resolved folder.

## Implementation

- Added `targetTimestampFolder` validation and UTC folder resolution for S3 and HDFS targets.
- Updated run statistics to record the resolved target URI.
- Added unit and integration coverage for formatting, validation, retries, and statistics.
- Documented configuration, folder formats, and retention expectations.
