### PR TITLE
chore(PLA-1108): run the shared org PR checks

### DIFF
--- a/.github/workflows/common-pr-checks.yml
+++ b/.github/workflows/common-pr-checks.yml
@@ -3,6 +3,9 @@ name: PR checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   common:
     uses: iomete/.github/.github/workflows/common-repository-pr-checks.yml@main

--- a/.github/workflows/common-pr-checks.yml
+++ b/.github/workflows/common-pr-checks.yml
@@ -1,0 +1,10 @@
+name: PR checks
+
+on:
+  pull_request:
+
+jobs:
+  common:
+    uses: iomete/.github/.github/workflows/common-repository-pr-checks.yml@main
+    with:
+      runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Turns on the shared org PR checks, so every pull request is scanned for secrets before it can be merged.
- No repo-specific setup: the check itself lives in the shared workflow and is maintained in one place.
- Only what a pull request adds is scanned, so anything already in history does not block unrelated work.

## Customer-facing
None (internal only).

Linear: https://linear.app/iomete/issue/PLA-1108/add-gitleaks-secret-scanning-to-ci-and-chart-publishing
